### PR TITLE
fix: dont load timing data of macros in OpenGUI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -48,7 +48,7 @@ original authors after Efabless Corporation has ceased operations.
 
 * `OpenROAD.OpenGUI`
 
-  * The LIBs are now loaded by default and the SPEFs if available.
+  * The LIBs are now loaded by default and the top-level SPEF if available.
 
 ## Documentation
 

--- a/librelane/scripts/openroad/gui.tcl
+++ b/librelane/scripts/openroad/gui.tcl
@@ -13,5 +13,25 @@
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 
-read_current_odb
-read_spefs
+puts "Reading OpenROAD database at '$::env(CURRENT_ODB)'…"
+if { [ catch {read_db $::env(CURRENT_ODB)} errmsg ]} {
+    puts stderr $errmsg
+    exit 1
+}
+
+set_global_vars
+
+define_corners $::env(DEFAULT_CORNER)
+
+foreach lib $::env(_PNR_LIBS) {
+    puts "Reading library file at '$lib'…"
+    read_liberty $lib
+}
+
+read_current_sdc
+
+if { [info exists ::env(_CURRENT_SPEF_BY_CORNER)] } {
+    set corner_name $::env(_CURRENT_CORNER_NAME)
+    puts "Reading top-level design parasitics for the '$corner_name' corner at '$::env(_CURRENT_SPEF_BY_CORNER)'…"
+    read_spef -corner $corner_name $::env(_CURRENT_SPEF_BY_CORNER)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.0.dev7"
+version = "2.4.0.dev8"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
I missed this one, sorry!

When a macro is part of the design, OpenInOpenROAD would attempt to load the spef of the macro, leading to a lot of warnings.
This doesn't work, even when the macro NL is loaded as OpenROAD seems to be flat by default and only sta is hierarchical. (Is that true?)

`gui.tcl` has been updated to only load the SPEF of the top-level design for the default corner.

Future improvements would be:
- Loading several corners at once
- Estimating routing delays if SPEF is not available

