### PR TITLE
ci: concurrency control

### DIFF
--- a/.github/scripts/compare_metrics.js
+++ b/.github/scripts/compare_metrics.js
@@ -9,7 +9,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 "use strict";
@@ -22,154 +22,212 @@
  * @param {string} token
  * @returns {string}
  */
-function compareMetricsWithBranch({ comparingDirectory, againstBranch, verbosity, table_out = null, token = "" }) {
-    const { spawnSync } = require("child_process");
+function compareMetricsWithBranch({
+  comparingDirectory,
+  againstBranch,
+  verbosity,
+  table_out = null,
+  token = "",
+  metricsRepo = null,
+}) {
+  const { spawnSync } = require("child_process");
 
-    let tableOutOpts = table_out ? ["--table-out", table_out] : [];
-    let allOpts = ["-m", "librelane.common.metrics", "compare-remote", comparingDirectory, "--branch", againstBranch, "--table-verbosity", verbosity,].concat(tableOutOpts)
+  let tableOutOpts = table_out ? ["--table-out", table_out] : [];
+  let metricRepoOpts = metricsRepo ? ["--metrics-repo", metricsRepo] : [];
+  let allOpts = [
+    "-m",
+    "librelane.common.metrics",
+    "compare-remote",
+    comparingDirectory,
+    "--branch",
+    againstBranch,
+    "--table-verbosity",
+    verbosity,
+    ...tableOutOpts,
+    ...metricRepoOpts,
+  ];
 
-    let child = spawnSync("python3", allOpts.concat(["--token", token]), { encoding: "utf8" });
+  let child = spawnSync("python3", allOpts.concat(["--token", token]), {
+    encoding: "utf8",
+  });
 
-    let result = "";
-    if (child.status != 0) {
-        throw new Error("Failed to create report: \n\n```\n" + child.stderr + "\n```");
-    } else {
-        result += "Metric comparisons are in beta. Please report bugs under the issues tab.\n---\n";
-        result += `> To create this report yourself, grab the metrics artifact from the CI run, extract them, and invoke \`python3 ${allOpts.join(' ')}\`.\n\n` + child.stdout;
-    }
+  let result = "";
+  if (child.status != 0) {
+    throw new Error(
+      "Failed to create report: \n\n```\n" + child.stderr + "\n```"
+    );
+  } else {
+    result +=
+      "Metric comparisons are in beta. Please report bugs under the issues tab.\n---\n";
+    result +=
+      `> To create this report yourself, grab the metrics artifact from the CI run, extract them, and invoke \`python3 ${allOpts.join(
+        " "
+      )}\`.\n\n` + child.stdout;
+  }
 
-    return result.trim();
-};
-
-/**
- * 
- * @param {Octokit} github 
- * @param {object} context 
- * @param {string} botUsername 
- * @param {string} body 
- */
-async function postOrUpdateComment({ github, context, botUsername, body }) {
-    const METRIC_REPORT_MARK = "<!-- MARK: METRICS REPORT -->";
-
-    let page = 1;
-    let allComments = [];
-    let comments = [];
-    do {
-        let response = await github.request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments?page={page}&per_page=100", {
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            page,
-        });
-        comments = response.data;
-        allComments = allComments.concat(comments);
-        page += 1;
-    } while (comments.length != 0);
-
-    let found = null;
-    for (let comment of allComments) {
-        if (comment.body.includes(METRIC_REPORT_MARK) && comment.user.login == botUsername) {
-            found = comment;
-            break;
-        }
-    }
-
-    let fn = github.rest.issues.createComment;
-    let request = {
-        issue_number: context.issue.number,
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        body: `${METRIC_REPORT_MARK}\n\n${body}`
-    };
-
-    if (found) {
-        request.comment_id = found.id;
-        fn = github.rest.issues.updateComment;
-    }
-
-    await fn(request);
+  return result.trim();
 }
 
 /**
- * 
- * @param {Octokit} github 
- * @param {object} context 
- * @param {string} botUsername 
- * @param {string} botToken 
+ *
+ * @param {Octokit} github
+ * @param {object} context
+ * @param {string} botUsername
+ * @param {string} body
+ */
+async function postOrUpdateComment({ github, context, botUsername, body }) {
+  const METRIC_REPORT_MARK = "<!-- MARK: METRICS REPORT -->";
+
+  let page = 1;
+  let allComments = [];
+  let comments = [];
+  do {
+    let response = await github.request(
+      "GET /repos/{owner}/{repo}/issues/{issue_number}/comments?page={page}&per_page=100",
+      {
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        page,
+      }
+    );
+    comments = response.data;
+    allComments = allComments.concat(comments);
+    page += 1;
+  } while (comments.length != 0);
+
+  let found = null;
+  for (let comment of allComments) {
+    if (
+      comment.body.includes(METRIC_REPORT_MARK) &&
+      comment.user.login == botUsername
+    ) {
+      found = comment;
+      break;
+    }
+  }
+
+  let fn = github.rest.issues.createComment;
+  let request = {
+    issue_number: context.issue.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    body: `${METRIC_REPORT_MARK}\n\n${body}`,
+  };
+
+  if (found) {
+    request.comment_id = found.id;
+    fn = github.rest.issues.updateComment;
+  }
+
+  await fn(request);
+}
+
+/**
+ *
+ * @param {Octokit} github
+ * @param {object} context
+ * @param {string} botUsername
+ * @param {string} botToken
  * @param {string} comparingDirectory
  * @param {string} againstBranch
+ * @param {string} metricsRepo
  */
-async function compareAndComment({ github, context, botUsername, botToken, comparingDirectory, againstBranch }) {
-    const fs = require("fs");
-    let body;
-    try {
-        body = compareMetricsWithBranch({ comparingDirectory, againstBranch, verbosity: "ALL", table_out: "./tables_all.md", token: botToken });
-        let tables = fs.readFileSync("./tables_all.md", { encoding: "utf8" });
+async function compareAndComment({
+  github,
+  context,
+  botUsername,
+  botToken,
+  comparingDirectory,
+  againstBranch,
+  metricsRepo = null,
+}) {
+  const fs = require("fs");
+  let body;
+  try {
+    body = compareMetricsWithBranch({
+      comparingDirectory,
+      againstBranch,
+      verbosity: "ALL",
+      table_out: "./tables_all.md",
+      token: botToken,
+      metricsRepo,
+    });
+    let tables = fs.readFileSync("./tables_all.md", { encoding: "utf8" });
 
-        let gistResponse = await github.rest.gists.create({
-            public: true,
-            description: `Results for ${context.repo.owner} / ${context.repo.repo}#${context.issue.number} (Run ${context.runId})`,
-            files: {
-                "10-ALL.md": {
-                    content: tables
-                }
-            }
-        });
+    let gistResponse = await github.rest.gists.create({
+      public: true,
+      description: `Results for ${context.repo.owner} / ${context.repo.repo}#${context.issue.number} (Run ${context.runId})`,
+      files: {
+        "10-ALL.md": {
+          content: tables,
+        },
+      },
+    });
 
-        body += `\n\nFull tables ► ${gistResponse.data.html_url}\n`;
-    } catch (e) {
-        body = e.message;
-        console.error(e.message)
-    }
+    body += `\n\nFull tables ► ${gistResponse.data.html_url}\n`;
+  } catch (e) {
+    body = e.message;
+    console.error(e.message);
+  }
 
-    await postOrUpdateComment({ github, context, botUsername, body })
+  await postOrUpdateComment({ github, context, botUsername, body });
 }
 
 module.exports = compareAndComment;
 
 if (require.main === module) {
-    // Test
-    try {
-        require("@octokit/rest");
-        require("commander");
-    } catch (error) {
-        console.error("Run 'yarn add @octokit/rest @octokit/plugin-paginate-rest commander'")
-        process.exit(-1);
-    }
-    const { Octokit } = require("@octokit/rest");
-    const { Command } = require('commander');
-    const script = new Command();
+  // Test
+  try {
+    require("@octokit/rest");
+    require("commander");
+  } catch (error) {
+    console.error(
+      "Run 'yarn add @octokit/rest @octokit/plugin-paginate-rest commander'"
+    );
+    process.exit(-1);
+  }
+  const { Octokit } = require("@octokit/rest");
+  const { Command } = require("commander");
+  const script = new Command();
 
-    script.command("comment")
-        .argument("directory", "The directory containing the generated metrics to compare")
-        .option("-i,--issue-number <issue-number>", "The number of the GitHub PR to comment on")
-        .option("-b,--branch <branch>", "The branch to compare against")
-        .option("-t,--token <token>", "The GitHub token to use")
-        .action((directory, options) => {
-            let octokit = new Octokit({
-                auth: options.token,
-            });
+  script
+    .command("comment")
+    .argument(
+      "directory",
+      "The directory containing the generated metrics to compare"
+    )
+    .option(
+      "-i,--issue-number <issue-number>",
+      "The number of the GitHub PR to comment on"
+    )
+    .option("-b,--branch <branch>", "The branch to compare against")
+    .option("-t,--token <token>", "The GitHub token to use")
+    .action((directory, options) => {
+      let octokit = new Octokit({
+        auth: options.token,
+      });
 
-            const context = {
-                repo: {
-                    owner: "librelane",
-                    repo: "librelane"
-                },
-                issue: {
-                    number: options.issueNumber
-                },
-                runId: "api_test"
-            };
+      const context = {
+        repo: {
+          owner: "librelane",
+          repo: "librelane",
+        },
+        issue: {
+          number: options.issueNumber,
+        },
+        runId: "api_test",
+      };
 
-            compareAndComment({
-                github: octokit,
-                context: context,
-                botUsername: "ohl-bot",
-                botToken: options.token,
-                comparingDirectory: directory,
-                againstBranch: options.branch
-            });
-        });
+      compareAndComment({
+        github: octokit,
+        context: context,
+        botUsername: "ohl-bot",
+        botToken: options.token,
+        comparingDirectory: directory,
+        againstBranch: options.branch,
+      });
+    });
 
-    script.parse();
+  script.parse();
 }

--- a/.github/scripts/compare_metrics.js
+++ b/.github/scripts/compare_metrics.js
@@ -33,7 +33,7 @@ function compareMetricsWithBranch({
   const { spawnSync } = require("child_process");
 
   let tableOutOpts = table_out ? ["--table-out", table_out] : [];
-  let metricRepoOpts = metricsRepo ? ["--metrics-repo", metricsRepo] : [];
+  let metricRepoOpts = metricsRepo ? ["--metric-repo", metricsRepo] : [];
   let allOpts = [
     "-m",
     "librelane.common.metrics",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     needs: [lint, prepare-test-matrices]
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     name: Build and Unit Test (Python ${{ matrix.python-version }})
     steps:
@@ -379,13 +379,15 @@ jobs:
           ipm install --ip-root $(realpath $IP_ROOT) --ipm-root ~/.ipm --version ${{ matrix.design.ipm_version }} ${{ matrix.design.name }}
 
       - name: Run Test
+        id: test_run
+        continue-on-error: true
         run: |
           if test ${{matrix.design.script}} = "None"
           then
             mkdir -p ${{ github.workspace }}/run
             sudo du -hs /nix/store/* | sort -h | tail -n 10
             sudo du -hs /nix/store/* | sort -h | tail -n 10 > before.txt
-            nix run --accept-flake-config .#librelane --\
+            nix run . --\
               --run-tag ${{ matrix.design.pdk }}-${{ matrix.design.scl }}\
               --pdk ${{ matrix.design.pdk }}\
               --scl ${{ matrix.design.scl }}\
@@ -393,7 +395,7 @@ jobs:
               --condensed\
               ${{ matrix.design.config }}
           else
-            nix develop --accept-flake-config --command\
+            nix develop --command\
               python3 ${{ matrix.design.script }}\
               --run-tag ${{ matrix.design.pdk }}-${{ matrix.design.scl }}\
               --pdk ${{ matrix.design.pdk }}\
@@ -401,32 +403,37 @@ jobs:
               --pdk-root ./.ciel-${{ matrix.design.pdk_family }}\
               --condensed
           fi
+
       - name: Upload Run Folder
-        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.design.test_name }}-${{ matrix.design.pdk }}-${{ matrix.design.scl }}
           path: ${{ matrix.design.run_dir }}
 
       - name: Fetch Metrics
-        if: ${{ always() }}
         run: |
-          nix develop --accept-flake-config --command librelane.state latest\
+          nix develop --command librelane.state latest\
               ${{ matrix.design.run_dir }}\
               --extract-metrics-to ${{ matrix.design.pdk }}-${{ matrix.design.scl }}-${{ matrix.design.test_name }}.metrics.json
+
       - name: Upload Metrics
-        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.design.pdk }}-${{ matrix.design.scl }}-${{ matrix.design.test_name }}.metrics.json
           path: ${{ matrix.design.pdk }}-${{ matrix.design.scl }}-${{ matrix.design.test_name }}.metrics.json
+
+      - name: Propagate test failure after uploading metrics
+        if: steps.test_run.outcome == 'failure'
+        run:
+          exit -1
   merge_metrics:
     name: Merge Metrics
     runs-on: ubuntu-22.04
     needs: test
-    if: ${{ always() }}
+    if: always()
     steps:
-      - name: Merge Artifacts
+      - id: metric_merge
+        name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
           name: metrics
@@ -435,7 +442,8 @@ jobs:
     name: Upload Metrics
     runs-on: ubuntu-22.04
     needs: [test, merge_metrics]
-    if: ${{ always() }}
+    # if there isn't at least one metric this exercise is pointless
+    if: needs.merge_metrics.result == 'success'
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -487,7 +495,7 @@ jobs:
           git push -fu origin $BRANCH_NAME # Force for if we have to re-run the CI for some reason
   publish:
     runs-on: ubuntu-22.04
-    needs: [build-linux-x86_64, build-docker, build-py]
+    needs: [build-docker, build-py]
     name: Publish (If Applicable)
     steps:
       - name: Check out repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
     - cron: "0 0 * * *"
   # Manual Dispatch
   workflow_dispatch:
+  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.number || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   prepare-test-matrices:
@@ -462,6 +466,7 @@ jobs:
               botToken: "${{ secrets.BOT_GITHUB_TOKEN }}",
               comparingDirectory: "current",
               againstBranch: "${{ github.base_ref }}",
+              metricsRepo: "${{ vars.METRICS_REPO }}",
             }).then(()=>{console.log("Done.");});
       - name: "[Push] Upload Metrics"
         env: 

--- a/Authors.md
+++ b/Authors.md
@@ -1,21 +1,29 @@
 # Authors
-All categories ordered by last name, alphabetically.
 
-## LibreLane Team
+All categories arranged alphabetically.
 
-LibreLane is curerntly maintained by the American University in Cairo
-Open Hardware Lab.
+> This list may be non-exhaustive and primarily reflects copyright holders for
+> significant portions of the code. See
+> https://github.com/librelane/librelane/graphs/contributors for a full list of
+> human authors.
 
+* Efabless Corporation \<https://efabless.com\> (until February 2023)
+* Leo Moser \<leo.moser@pm.me\>
 * Mohamed Gaber \<me@donn.website\>
 * Mohamed Shalan \<mshalan@aucegypt.edu\>
 
-## OpenLane 2.0 Core Developers
+## OpenLane
+
+LibreLane is the successor to OpenLane, developed, copyrighted and released as
+open-source by Efabless Corporation.
+
+### OpenLane 2.0 Core Developers
 
 * Kareem Farid \<kareem.farid@efabless.com\>
 * Mohamed Gaber \<donn@efabless.com\>
 * Mohamed Shalan \<mshalan@efabless.com\>
 
-## OpenLane 1.0 Core Developers
+### OpenLane 1.0 Core Developers
 
 * Manar Abdelatty \<manarabdelaty@efabless.com\>
 * Kareem Farid \<kareem.farid@efabless.com\>
@@ -34,7 +42,3 @@ Open Hardware Lab.
 * Harald Pretl \<harald.pretl@jku.at\>
 * Tom Spyrou \<aspyrou@eng.ucsd.edu\>
 * Andrew Wright \<andrew.wright@efabless.com\>
-
-## All Contributors
-
-https://github.com/librelane/librelane/graphs/contributors

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from OpenLane
 #

--- a/librelane/__main__.py
+++ b/librelane/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from OpenLane
 #

--- a/librelane/scripts/odbpy/ioplace_parser/__init__.py
+++ b/librelane/scripts/odbpy/ioplace_parser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from ioplace_parser
 #

--- a/librelane/scripts/odbpy/ioplace_parser/parse.py
+++ b/librelane/scripts/odbpy/ioplace_parser/parse.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from ioplace_parser
 #

--- a/test/ioplace_parser/conftest.py
+++ b/test/ioplace_parser/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from ioplace_parser
 #

--- a/test/ioplace_parser/test_parse.py
+++ b/test/ioplace_parser/test_parse.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from ioplace_parser
 #

--- a/test/steps/test_tclstep.py
+++ b/test/steps/test_tclstep.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The American University in Cairo
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from OpenLane
 #


### PR DESCRIPTION
The CI will now only allow one instance of a CI at a time for either pushes, pull requests, schedules, or manual dispatches. This is to help save compute time and my own sanity.

Additionally, the metrics repo can now be passed to `compare_metrics.js`. Which was prettier-formated while I was at it.

Also clarify copyright situation and update Authors.md.