### PR TITLE
feat: flatten values of `List[Path]`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -64,6 +64,9 @@ original authors after Efabless Corporation has ceased operations.
 
 ## Misc. Enhancements/Bugfixes
 
+* `librelane.config.Variable`
+  * Variables of type `List[Path]` now flatten lists of lists so multiple globs
+    may be used within the same configuration variable.
 * `librelane.state.DesignFormat`
   * Added new dynamic property `.value.optional` which cannot be defined for new
     enum members and always returns `False`.

--- a/librelane/config/config.py
+++ b/librelane/config/config.py
@@ -705,6 +705,9 @@ class Config(GenericImmutableDict[str, Any]):
                 readable_paths=readable_paths,
             )
         )
+        
+        # Flatten Verilog files so that multiple globs can be combined
+        mutable["VERILOG_FILES"] = Config.__flatten_list(mutable["VERILOG_FILES"])
 
         processed, design_warnings, design_errors = Config.__process_variable_list(
             mutable,
@@ -1023,3 +1026,14 @@ class Config(GenericImmutableDict[str, Any]):
                         warnings.append(f"An unknown key '{key}' was provided.")
 
         return (final, warnings, errors)
+
+    # Takes a list of the form [1, [2,3]] and converts it to [1,2,3]
+    def __flatten_list(in_list: List):
+        out_list = []
+        for item in in_list:
+            if isinstance(item, List):
+                for subitem in item:
+                    out_list.append(subitem)
+            else:
+                out_list.append(item)
+        return out_list

--- a/librelane/config/config.py
+++ b/librelane/config/config.py
@@ -705,9 +705,6 @@ class Config(GenericImmutableDict[str, Any]):
                 readable_paths=readable_paths,
             )
         )
-        
-        # Flatten Verilog files so that multiple globs can be combined
-        mutable["VERILOG_FILES"] = Config.__flatten_list(mutable["VERILOG_FILES"])
 
         processed, design_warnings, design_errors = Config.__process_variable_list(
             mutable,
@@ -1026,14 +1023,3 @@ class Config(GenericImmutableDict[str, Any]):
                         warnings.append(f"An unknown key '{key}' was provided.")
 
         return (final, warnings, errors)
-
-    # Takes a list of the form [1, [2,3]] and converts it to [1,2,3]
-    def __flatten_list(in_list: List):
-        out_list = []
-        for item in in_list:
-            if isinstance(item, List):
-                for subitem in item:
-                    out_list.append(subitem)
-            else:
-                out_list.append(item)
-        return out_list

--- a/librelane/config/variable.py
+++ b/librelane/config/variable.py
@@ -730,6 +730,7 @@ class Variable:
         )
 
     # Flatten list. Note: Must modify value, not return a new list.
+    @staticmethod
     def __flatten_list(value: list):
         new_list = []
         for item in value:

--- a/librelane/config/variable.py
+++ b/librelane/config/variable.py
@@ -440,6 +440,9 @@ class Variable:
             return_value = list()
             raw = value
             if isinstance(raw, list) or isinstance(raw, tuple):
+                if validating_type == List[Path]:
+                    if any(isinstance(item, List) for item in raw):
+                        Variable.__flatten_list(value)
                 pass
             elif is_string(raw):
                 if not permissive_typing:
@@ -725,3 +728,15 @@ class Variable:
             and self.type == rhs.type
             and self.default == rhs.default
         )
+
+    # Flatten list. Note: Must modify value, not return a new list.
+    def __flatten_list(value: list):
+        new_list = []
+        for item in value:
+            if isinstance(item, list):
+                for sub_item in item:
+                    new_list.append(sub_item)
+            else:
+                new_list.append(item)
+
+        value[:] = new_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.0.dev9"
+version = "2.4.0.dev10"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
Allows verilog files to be defined with multiple globs, for example:
```Yaml
VERILOG_FILES: 
  - dir::rtl/folder1/*.sv
  - dir::rtl/folder2/*.sv
```