### PR TITLE
steps: In TclStep, overwrite env file, don't append

### DIFF
--- a/librelane/steps/tclstep.py
+++ b/librelane/steps/tclstep.py
@@ -255,7 +255,7 @@ class TclStep(Step):
         #
         # Emplace file to be sourced in dict with key ``_TCL_ENV_IN``
         env = os.environ.copy()
-        with open(env_in_file, "a+") as f:
+        with open(env_in_file, "w") as f:
             for key, value in env_in:
                 if key in env and env[key] == value:
                     continue


### PR DESCRIPTION
Append doesn't seem necessary and for steps that call multiple process, the env keeps growing indefinitely, up to 100M+ when you have lots of macros and slowing everything down.