### PR TITLE
feat: Add support for nested dicts in tcl

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -222,6 +222,10 @@
 
 ## Misc. Enhancements/Bugfixes
 
+* `librelane.common`
+
+  * `_eval_env`: Add support for nested dicts in tcl
+
 * `openlane.flows`
 
   * `SequentialFlow`

--- a/librelane/common/tcl.py
+++ b/librelane/common/tcl.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,11 +72,49 @@ class TclUtils(object):
                 if value is not None:
                     env_out[match.group(1)] = value
 
+        def py_dict(command, target=None, *args):
+            if command == "set":
+                if match := _env_rx.fullmatch(target):
+
+                    if len(args) > 1:
+                        value = args[-1]
+                        keys = args[:-1]
+
+                        # Create new dict if it does not exist
+                        if not match.group(1) in env_out:
+                            env_out[match.group(1)] = {}
+
+                        # set ::env(...) [dict create]
+                        # will create an empty string ""
+                        # convert into an empty dictionary
+                        if env_out[match.group(1)] == "":
+                            env_out[match.group(1)] = {}
+
+                        # Set key value pair
+                        cur_dict = env_out[match.group(1)]
+
+                        # Create all nested dicts
+                        for key in keys[:-1]:
+                            if key in cur_dict:
+                                cur_dict = cur_dict[key]
+                            else:
+                                cur_dict[key] = {}
+                                cur_dict = cur_dict[key]
+
+                        # Finally set the value
+                        cur_dict[keys[-1]] = value
+
         py_set_name = interpreter.register(py_set)
+        py_dict_name = interpreter.register(py_dict)
         interpreter.call("rename", py_set_name, "_py_set")
         interpreter.call("rename", "set", "_orig_set")
+        interpreter.call("rename", py_dict_name, "_py_dict")
+        interpreter.call("rename", "dict", "_orig_dict")
         interpreter.eval(
             "proc set args { _py_set {*}$args; tailcall _orig_set {*}$args; }"
+        )
+        interpreter.eval(
+            "proc dict args { _py_dict {*}$args; tailcall _orig_dict {*}$args; }"
         )
 
         interpreter.eval(tcl_in)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "3.0.0.dev25"
+version = "3.0.0.dev26"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
Allows to create nested dicts, as required in the PDK config for:

- the `LAYERS_RC` dict
- the `VIAS_R` dict
- the `LIB` dict

In preparation for upstreaming support for the IHP PDK.