### PR TITLE
[WONTFIX] Fixed tilde (~) not expanding

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,10 @@
 ## Documentation
 -->
 
+# 2.4.2
+
+* Fixed tilde (~) not being expanded for home directory
+
 # 2.4.1
 
 ## Misc. Enhancements/Bugfixes

--- a/librelane/__main__.py
+++ b/librelane/__main__.py
@@ -83,6 +83,10 @@ def run(
         TargetFlow: Optional[Type[Flow]] = Flow.factory.get("Classic")
 
         for config_file in config_files:
+            # expands the pdk-root path
+            pdk_root = (
+                os.path.expanduser(pdk_root) if isinstance(pdk_root, str) else None
+            )
             if meta := Config.get_meta(config_file):
                 # to maintain backwards compat, in 3 you will need to explicitly
                 # set the flow you're substituting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.1"
+version = "2.4.2"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
### Bug description
Librelane fails to expand the home path with a tilde (~) before passing the config down to the config function.


Upon a short inspection with pdb, it turned out that right before the failure, the path didn't expand right before
it hits the InvalidConfig exception.
This has been narrowed down due to
- `PDK_ROOT=` environment variable 
- "$HOME" 
working as intended.


This is a one-liner fix.
```[nix-shell:~/librelane]$ librelane --manual-pdk --pdk-root=~/.ciel --pdk ihp-sg13g2 ../my_designs/pm32-example/config.json
> /home/de_generic/librelane/librelane/__main__.py(90)run()
-> pdk_root = os.path.expanduser(pdk_root) if isinstance(pdk_root, str) else None
(Pdb) locals()
{'ctx': <cloup._context.Context object at 0x7bffd6b0af30>, 'flow_name': None, BEFORE->>>> 'pdk_root': '~/.ciel', 'pdk': 'ihp-sg13g2', 'scl': None, 'config_files': ('../my_designs/pm32-example/config.json',), 'tag': None, 'last_run': False, 'frm': None, 'to': None, 'skip': (), 'overwrite': False, 'reproducible': None, 'with_initial_state': None, 'config_override_strings': (), '_force_run_dir': None, 'design_dir': None, 'initial_state_element_override': (), 'view_save_path': None, 'ef_view_save_path': None, 'TargetFlow': <class 'librelane.flows.classic.Classic'>, 'config_file': '../my_designs/pm32-example/config.json'}
(Pdb) continue
> /home/de_generic/librelane/librelane/__main__.py(92)run()
-> if meta := Config.get_ueta(config_file):
(Pdb) locals()
{'ctx': <cloup._context.Context object at 0x7bffd6b0af30>, 'flow_name': None, AFTER->>>> 'pdk_root': '/home/de_generic/.ciel', 'pdk': 'ihp-sg13g2', 'scl': None, 'config_files': ('../my_designs/pm32-example/config.json',), 'tag': None, 'last_run': False, 'frm': None, 'to': None, 'skip': (), 'overwrite': False, 'reproducible': None, 'with_initial_state': None, 'config_override_strings': (), '_force_run_dir': None, 'design_dir': None, 'initial_state_element_override': (), 'view_save_path': None, 'ef_view_save_path': None, 'TargetFlow': <class 'librelane.flows.classic.Classic'>, 'config_file': '../my_designs/pm32-example/config.json'}```
