### PR TITLE
fix: `KLayout.GUI` not using `state_in.get()`

### DIFF
--- a/librelane/steps/klayout.py
+++ b/librelane/steps/klayout.py
@@ -480,7 +480,7 @@ class OpenGUI(KLayoutStep):
 
         layout = state_in[DesignFormat.DEF]
         if self.config["KLAYOUT_GUI_USE_GDS"]:
-            if gds := state_in[DesignFormat.GDS]:
+            if gds := state_in.get(DesignFormat.GDS):
                 layout = gds
         assert isinstance(layout, Path)
 


### PR DESCRIPTION
Without this, it ends in KeyError ...