### PR TITLE
Update nix-eda to 5.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -226,6 +226,7 @@
   * Updated Netgen to `1.5.295`
   * Updated Yosys to `0.54`
     * Replaced Synlig with [Slang](https://github.com/povik/yosys-slang)
+  * Updated Verilator to `5.038`
 * Updated OpenROAD to `341650e`
 * Updated OpenSTA to `ffabd65`
 

--- a/flake.lock
+++ b/flake.lock
@@ -81,16 +81,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750853707,
-        "narHash": "sha256-qEWB2wesmKI2y7F1d1DWBHxCA4ohtelZiZPpL1fEWgc=",
+        "lastModified": 1753887907,
+        "narHash": "sha256-qQnme9LyCv5+Rz0K/A0rstevVny3N6zP9E8h6HuV6Ac=",
         "owner": "fossi-foundation",
         "repo": "nix-eda",
-        "rev": "b488fa6428c07de92cbd491e52fbf9691d069b9b",
+        "rev": "7e00bf5edc8c750ae1392e28d51ad83b693f812b",
         "type": "github"
       },
       "original": {
         "owner": "fossi-foundation",
-        "ref": "donn/nixos_2505",
+        "ref": "5.2.0",
         "repo": "nix-eda",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
   description = "open-source infrastructure for implementing chip design flows";
 
   inputs = {
-    nix-eda.url = "github:fossi-foundation/nix-eda/donn/nixos_2505";
+    nix-eda.url = "github:fossi-foundation/nix-eda/5.2.0";
     libparse.url = "github:efabless/libparse-python";
     ciel.url = "github:fossi-foundation/ciel";
     devshell.url = "github:numtide/devshell";

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2741,7 +2741,7 @@ class OpenGUI(OpenSTAStep):
 
     inputs = [
         DesignFormat.ODB,
-        DesignFormat.SPEF.mkOptional(),
+        # DesignFormat.SPEF.mkOptional(),
     ]
     outputs = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "3.0.0.dev28"
+version = "3.0.0.dev29"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
This PR updates nix-eda to 5.2.0.

Also a small fix: Comment out `DesignFormat.SPEF.mkOptional()` in OpenGUI as it's currently broken in dev.