### PR TITLE
cli: new command `librelane.help`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -76,6 +76,10 @@ original authors after Efabless Corporation has ceased operations.
 
 * `CLI`
 
+  * New command, `librelane.help` that can be supplied with the ID of either a
+    flow or step and it prints the full markdown help for the flow or step in
+    the terminal.
+
   * Various fixes to `--ef-save-views-to` to better align with the Caravel User
     Project format: SDFs now save in the right spot and reports are saved
     correctly.

--- a/librelane/flows/flow.py
+++ b/librelane/flows/flow.py
@@ -375,7 +375,7 @@ class Flow(ABC):
         self.progress_bar = FlowProgressBar(self.name)
 
     @classmethod
-    def get_help_md(Self, myst_anchors: bool = True) -> str:  # pragma: no cover
+    def get_help_md(Self, myst_anchors: bool = False) -> str:  # pragma: no cover
         """
         :returns: rendered Markdown help for this Flow
         """
@@ -415,10 +415,10 @@ class Flow(ABC):
         flow_config_vars = Self.config_vars
 
         if len(flow_config_vars):
+            config_var_anchors = f"({slugify(Self.__name__, lower=True)}-config-vars)="
             result += textwrap.dedent(
                 f"""
-                ({slugify(Self.__name__, lower=True)}-config-vars)=
-
+                {config_var_anchors * myst_anchors}
                 #### Flow-specific Configuration Variables
 
                 | Variable Name | Type | Description | Default | Units |
@@ -435,18 +435,14 @@ class Flow(ABC):
         if len(Self.Steps):
             result += "#### Included Steps\n"
             for step in Self.Steps:
-                if hasattr(step, "long_name"):
-                    name = step.long_name
-                elif hasattr(step, "name"):
-                    name = step.name
-                else:
-                    name = step.id
+                imp_id = step.get_implementation_id()
                 if myst_anchors:
-                    result += (
-                        f"* [`{step.id}`](./step_config_vars.md#{slugify(name)})\n"
-                    )
+                    result += f"* [`{step.id}`](./step_config_vars.md#step-{slugify(imp_id, lower=True)})\n"
                 else:
-                    result += f"* {step.id}"
+                    variant_str = ""
+                    if imp_id != step.id:
+                        variant_str = f" (implementation: `{imp_id}`)"
+                    result += f"* `{step.id}`{variant_str}\n"
 
         return result
 

--- a/librelane/help/__main__.py
+++ b/librelane/help/__main__.py
@@ -1,0 +1,39 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ..common.cli import formatter_settings
+from ..flows import Flow
+from ..steps import Step
+from ..logging import console
+
+import cloup
+
+
+@cloup.command(formatter_settings=formatter_settings)
+@cloup.argument("step_or_flow")
+@cloup.pass_context
+def cli(ctx, step_or_flow):
+    """
+    Displays rich help for the step or flow in question.
+    """
+    if TargetFlow := Flow.factory.get(step_or_flow):
+        TargetFlow.display_help()
+    elif TargetStep := Step.factory.get(step_or_flow):
+        TargetStep.display_help()
+    else:
+        console.log(f"Unknown Flow or Step '{step_or_flow}'.")
+        ctx.exit(-1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.0.dev12"
+version = "2.4.0.dev13"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does
@@ -65,6 +65,7 @@ librelane = "librelane.__main__:cli"
 "librelane.steps" = "librelane.steps.__main__:cli"
 "librelane.config" = "librelane.config.__main__:cli"
 "librelane.state" = "librelane.state.__main__:cli"
+"librelane.help" = "librelane.help.__main__:cli"
 "librelane.env_info" = "librelane:env_info_cli"
 
 [build-system]


### PR DESCRIPTION
New command, `librelane.help` that can be supplied with the ID of either a flow or step and it prints the full markdown help for the flow or step in the terminal.