### PR TITLE
fix: incompatibility between #688 and #612

### DIFF
--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2741,7 +2741,7 @@ class OpenGUI(OpenSTAStep):
 
     inputs = [
         DesignFormat.ODB,
-        # DesignFormat.SPEF.mkOptional(),
+        DesignFormat.SPEF.mkOptional(),
     ]
     outputs = []
 

--- a/librelane/steps/tclstep.py
+++ b/librelane/steps/tclstep.py
@@ -161,7 +161,8 @@ class TclStep(Step):
 
         for input in self.inputs:
             key = f"CURRENT_{input.id.upper()}"
-            env[key] = TclStep.value_to_tcl(state[input])
+            if input_path := state.get_by_df(input):
+                env[key] = TclStep.value_to_tcl(input_path)
 
         for output in self.outputs:
             if output.multiple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "3.0.0.dev30"
+version = "3.0.0.dev31"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
Fixes a minor incompatibility between #688 and #612 that causes a crash when TclSteps have a missing optional input.

In `main`, `[]` is guaranteed to return a result - `None`. So the error didn't bubble up.