### PR TITLE
feat: `Magic.SpiceExtraction`: replace `MAGIC_NO_EXT_UNIQUE` with enum `MAGIC_EXT_UNIQUE`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,10 @@
 
 ## Steps
 
+* `Magic.SpiceExtraction`: Added `MAGIC_EXT_UNIQUE` to replace `MAGIC_NO_EXT_UNIQUE`
+
+  * Allowed values are: "all", "notopports", "noports", "none"
+
 * `Yosys.Synthesis`: Added `SLANG_ARGUMENTS`, which is used to pass arguments to the Slang frontend.
 
   * `KLayout.StreamOut`: Added `KLAYOUT_CONFLICT_RESOLUTION` which specifies the conflict resolution if a cell name conflict arises. (Default: "RenameCell")

--- a/librelane/scripts/magic/extract_spice.tcl
+++ b/librelane/scripts/magic/extract_spice.tcl
@@ -79,9 +79,11 @@ extract no capacitance
 extract no coupling
 extract no resistance
 extract no adjust
-if { ! $::env(MAGIC_NO_EXT_UNIQUE) } {
-    extract unique
+
+if { $::env(MAGIC_EXT_UNIQUE) != "none" } {
+    extract unique $::env(MAGIC_EXT_UNIQUE)
 }
+
 # extract warn all
 extract
 

--- a/librelane/steps/magic.py
+++ b/librelane/steps/magic.py
@@ -458,15 +458,18 @@ class SpiceExtraction(MagicStep):
         Variable(
             "MAGIC_EXT_ABSTRACT_CELLS",
             Optional[List[str]],
-            "A list of regular experssions which are matched against the cells of a "
+            "A list of regular expressions which are matched against the cells of a "
             + "the design. Matches are abstracted (black-boxed) during SPICE extraction.",
         ),
         Variable(
-            "MAGIC_NO_EXT_UNIQUE",
-            bool,
-            "Enables connections by label in LVS by skipping `extract unique` in Magic extractions.",
-            default=False,
-            deprecated_names=["LVS_CONNECT_BY_LABEL"],
+            "MAGIC_EXT_UNIQUE",
+            Literal["all", "notopports", "noports", "none"],
+            'Runs `extract unique` with the specified option. The default is "all", and "none" disables `extract unique`, allowing connections between separate nets by label in LVS.',
+            default="all",
+            deprecated_names=[
+                ("MAGIC_NO_EXT_UNIQUE", lambda o: "none" if o else "all"),
+                ("LVS_CONNECT_BY_LABEL", lambda o: "none" if o else "all"),
+            ],
         ),
         Variable(
             "MAGIC_EXT_SHORT_RESISTOR",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "3.0.0.dev33"
+version = "3.0.0.dev34"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
Allowed values are: "all", "notopports", "noports", "none"

This allows for situations where only the top ports should be connected by label, or the other way around.

---

Depends on https://github.com/librelane/librelane-step-unit-tests/pull/2