### PR TITLE
feat!: cli: reject paths with possible tilde expansion failures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,15 @@
 <!--
-  * Using my modified version of mdformat:
-  nix run .#mdformat -- --wrap 80 --end-of-line lf Changelog.md
--->
 
-<!--
+Formatting the Changelog
+------------------------
+
+* Using Donn's modified version of mdformat:
+
+  nix run .#mdformat -- --wrap 80 --end-of-line lf Changelog.md
+
+Section Order
+-------------
+
 ## CLI
 ## Steps
 ## Flows
@@ -12,38 +18,46 @@
 ## Misc. Enhancements/Bugfixes
 ## API Breaks
 ## Documentation
+
+Style Notes
+------------
+
+* Always list steps alphabetically.
+
+* Always use the past tense for actions (created, added…)
+
+* New steps are always "Created", new variables are always "Added".
+  * Variables are "removed" or "deprecated." Always explain why, and for
+    deprecated variables, mention the replacement.
+
 -->
 
 # 3.0.0
 
 ## Steps
 
-* `Magic.SpiceExtraction`: Added `MAGIC_EXT_UNIQUE` to replace `MAGIC_NO_EXT_UNIQUE`
-
-  * Allowed values are: "all", "notopports", "noports", "none"
-
-* `Yosys.Synthesis`: Added `SLANG_ARGUMENTS`, which is used to pass arguments to the Slang frontend.
-
-  * `KLayout.StreamOut`: Added `KLAYOUT_CONFLICT_RESOLUTION` which specifies the conflict resolution if a cell name conflict arises. (Default: "RenameCell")
-
-    * Allowed values: "AddToCell", "OverwriteCell", "RenameCell" and "SkipNewCell"
-
-* `KLayout.DRC`
-
-  * Add support for ihp-sg13g2
-
-* Add `KLayout.LVS` step
-
-  * Add support for ihp-sg13g2
-
-* Add `OpenROAD.WriteCDL` step
-
-  * Write the CDL netlist of a design
-
 * `Checker.HoldViolations`
 
   * Changed default value of `HOLD_VIOLATION_CORNERS` to `['*']`, which will
     raise an error for hold violations on *any* corners.
+
+* `KLayout.DRC`
+
+  * Added support for ihp-sg13g2.
+
+* Created `KLayout.LVS`
+
+  * Currently only supports ihp-sg13g2.
+
+* `KLayout.StreamOut`: Added `KLAYOUT_CONFLICT_RESOLUTION` which specifies the
+  conflict resolution if a cell name conflict arises. (Default: "RenameCell")
+
+  * Allowed values: "AddToCell", "OverwriteCell", "RenameCell" and "SkipNewCell"
+
+* `Magic.SpiceExtraction`: Added `MAGIC_EXT_UNIQUE` to replace
+  `MAGIC_NO_EXT_UNIQUE`
+
+  * Allowed values are: "all", "notopports", "noports", "none"
 
 * `Odb.*`
 
@@ -69,10 +83,10 @@
 
 * `Odb.FuzzyDiodePlacement`, `Odb.HeuristicDiodeInsertion`
 
-* Steps no longer assume `DIODE_CELL` exists and fall back to doing nothing.
+  * Steps no longer assume `DIODE_CELL` exists and fall back to doing nothing.
 
-* `HEURISTIC_ANTENNA_THRESHOLD` has been made optional, steps do nothing if it
-  is unset.
+  * `HEURISTIC_ANTENNA_THRESHOLD` has been made optional, steps do nothing if it
+    is unset.
 
 * `OpenROAD.*`
 
@@ -209,18 +223,33 @@
 
   * Removes the placement status of all instances.
 
+* Created `OpenROAD.WriteCDL`
+
+  * Writes the CDL netlists for a database.
+
 * `Yosys.*Synthesis`
 
   * Added `SYNTH_CORNER`: a step-specific override for `DEFAULT_CORNER`.
-  
+
   * Added `SYNTH_NORMALIZE_SINGLE_BIT_VECTORS`: `true` by default, it converts
     vectors with the shape `[0:0]` to normal wires for backwards compatibility
-    with older designs. See https://github.com/YosysHQ/yosys/pull/5095
-    for more info.
+    with older designs. See https://github.com/YosysHQ/yosys/pull/5095 for more
+    info.
+
+* `Yosys.Synthesis`
+
+  * `synlig` has been replaced by `yosys-slang` as the alternative frontend for
+    superior SystemVerilog support.
+
+    * Added `SLANG_ARGUMENTS`, which is used to pass arguments to the Slang
+      frontend at the user's own risk.
+
+    * `USE_SYNLIG` deprecated and replaced with `USE_SLANG`.
 
 ## Flows
 
 * Classic
+
   * Added `OpenROAD.DumpRCValues` immediately after floorplanning.
 
 ## Tool Updates
@@ -245,18 +274,21 @@
 
 ## Misc. Enhancements/Bugfixes
 
-* Store hashes for each PDK family separately
+* `CLI`
 
-  * Renamed `open_pdks_rev` to `pdk_hashes.yaml`
-  * Add hash for ihp-sg13g2
-  * Rename `PDK_ihp-sg13g2` define to `PDK_ihp_sg13g2`
-  * Metrics: split `pdk-scl-design_name` triple from the right, since ihp-sg13g2 contains a `-`
+  * Paths provided over the terminal that start with a tilde are now rejected
+    and result in an error, as they typically mean POSIX shell tilde expansion
+    has failed. This is a compromise solution as tilde expansion within
+    LibreLane itself would be POSIX-ly incorrect, yet, many users pass quoted
+    tildes and then are surprised when it doesn't work.
+    * Relative paths that start with a genuine tilde must be provided as
+      absolute paths.
 
 * `librelane.common`
 
   * `_eval_env`: Add support for nested dicts in tcl
 
-* `openlane.flows`
+* `librelane.flows`
 
   * `SequentialFlow`
     * Substitutions are now to be strictly consumed by the subclass initializer,
@@ -269,12 +301,12 @@
       substitutions, instead of the second "original"
       `OpenROAD.DetailedPlacement` in the flow.
 
-* `openlane.config`
+* `librelane.config`
 
   * `meta.substituting_steps` now only apply to the sequential flow declared in
     `meta.flow` and not all flows.
 
-* `openlane.state`
+* `librelane.state`
 
   * `DesignFormat`
     * Now a dataclass encapsulating the information about the DesignFormat
@@ -291,12 +323,12 @@
     * States initialized with keys that have values that are `None` now remove
       said keys.
 
-* `openlane.steps`
+* `librelane.steps`
 
   * TclStep
     * All `Decimal` values are now passed to Tcl in exponent notation.
 
-* `openlane.config`
+* `librelane.config`
 
   * Moved a number of global variables:
     * `WIRE_LENGTH_THRESHOLD` moved from global variables to
@@ -310,14 +342,27 @@
   * Changed some `decimal.Decimal` initializations to use integers or strings
     instead of floats.
 
+* Store hashes for each PDK family separately
+
+  * Renamed `open_pdks_rev` to `pdk_hashes.yaml`
+  * Add hash for ihp-sg13g2
+  * Rename `PDK_ihp-sg13g2` define to `PDK_ihp_sg13g2`
+  * Metrics: split `pdk-scl-design_name` triple from the right, since ihp-sg13g2
+    contains a `-`
+
 ## API Breaks
 
-* `KLayout.StreamOut` now behaves differently as the default for cell conflict resolution has been changed from "AddToCell" to "RenameCell", which is a safer.
+* `CLI`
 
-	* To retain the old behavior, set `KLAYOUT_CONFLICT_RESOLUTION` to "AddToCell".
-	* It may be necessary to set `KLAYOUT_CONFLICT_RESOLUTION` to "SkipNewCell" to match the old macro integration behavior of magic.
+  * Paths provided over the terminal that start with a tilde are now rejected
+    and result in an error, as they typically mean POSIX shell tilde expansion
+    has failed. This is a compromise solution as tilde expansion within
+    LibreLane itself would be POSIX-ly incorrect, yet, many users pass quoted
+    tildes and then are surprised when it doesn't work.
+    * Relative paths that start with a genuine tilde must be provided as
+      absolute paths.
 
-* `*`
+* All Steps
 
   * `{GPL,DPL}_CELL_PADDING`, `PL_MAX_DISPLACEMENT_{X,Y}` now all integers to
     match OpenROAD.
@@ -328,6 +373,15 @@
   * `HOLD_VIOLATION_CORNERS` now defaulting to all corners will require designs
     that have hold violations at non-typical corners to set its value explicitly
     to `["*tt*"]`.
+
+* `KLayout.StreamOut` now behaves differently as the default for cell conflict
+  resolution has been changed from "AddToCell" to "RenameCell", which is a
+  safer.
+
+  * To retain the old behavior, set `KLAYOUT_CONFLICT_RESOLUTION` to
+    "AddToCell".
+  * It may be necessary to set `KLAYOUT_CONFLICT_RESOLUTION` to "SkipNewCell" to
+    match the old macro integration behavior of magic.
 
 * `Odb.AddRoutingObstructions`, `Odb.AddPDNObstructions`
 
@@ -510,7 +564,7 @@ original authors after Efabless Corporation has ceased operations.
 * Enhanced resilience against permission issues with containerized setups.
 
   * Temporary directories are no longer mounted.
-  
+
   * Docker and Podman are both tested in CI.
 
 * Worked around an issue with Google Colaboratory where if `PATH` is set,

--- a/librelane/flows/cli.py
+++ b/librelane/flows/cli.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sys
 from functools import partial, wraps
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Union
@@ -21,12 +26,15 @@ from click import (
     Parameter,
     echo,
 )
+from click.formatting import join_options
 from cloup import (
     option,
     argument,
     option_group,
     Choice,
-    Path,
+    Argument,
+    Option as CloupOption,
+    Path as CloupPath,
 )
 from cloup.constraints import (
     mutually_exclusive,
@@ -37,6 +45,70 @@ from .flow import Flow
 from ..common import set_tpe, cli, get_pdk_hash, _get_process_limit
 from ..logging import set_log_level, verbose, err, options, LogLevels
 from ..state import State, InvalidState
+
+
+class Option(CloupOption):
+    """
+    A slight modification of cloup.Option that consumes the environment
+    variable(s) in envvar upon use.
+    """
+
+    def resolve_envvar_value(self, ctx: Context) -> Optional[str]:
+        if self.envvar is None:
+            return None
+        evs = self.envvar
+        if isinstance(evs, str):
+            evs = [evs]
+        for envvar in self.envvar:
+            rv = os.environ.pop(envvar, None)
+            if rv:
+                return rv
+        return None
+
+
+class Path(CloupPath):
+    """
+    A modification of cloup.Path that rejects paths starting with a tilde (~)
+    as too ambiguous. This is because of user confusion.
+    """
+
+    def convert(
+        self,
+        value: Union[str, os.PathLike[str]],
+        param: Optional[Parameter],
+        ctx: Optional[Context],
+    ):
+        value = str(value)
+        assert param is not None
+        assert ctx is not None
+
+        is_cmd = False
+        if sys.platform == "win32":
+            import psutil
+
+            is_cmd = psutil.Process(os.getppid()).name().lower().endswith("cmd.exe")
+        if not is_cmd and value.startswith("~"):
+            usage, _ = join_options(param.opts)
+            if isinstance(param, Argument):
+                usage = ""
+            buffer = f"'{value}' starts with a tilde, which is ambiguous.\n"
+            buffer += "  * If you meant your home directory, make sure your POSIX shell is able to expand the tilde:\n"
+            buffer += f"    * GOOD: {ctx.command_path} {usage} {value}   …\n"
+            if usage != "":
+                buffer += f"    * BAD:  {ctx.command_path} {usage}={value}   …\n"
+            buffer += f'    * BAD:  {ctx.command_path} {usage} "{value}" …\n'
+            env_vars = []
+            if param.envvar is not None:
+                if isinstance(param.envvar, str):
+                    env_vars = [param.envvar]
+                else:
+                    env_vars = list(param.envvar)
+            for var in env_vars:
+                buffer += f"    * GOOD: {var}={value}   {ctx.command_path} …\n"
+                buffer += f'    * BAD:  {var}="{value}" {ctx.command_path} …\n'
+            buffer += '  * If you want a relative file or directory that starts with a literal "~", use an absolute path.\n'
+            self.fail(buffer, param, ctx)
+        return super().convert(value, param, ctx)
 
 
 def set_log_level_cb(
@@ -181,7 +253,7 @@ def cloup_flow_opts(
         Ciel is used by default for this CLI or not.
     :returns: The wrapper
     """
-    o = partial(option, show_default=True)
+    o = partial(option, cls=CloupOption, show_default=True)
 
     def decorate(f):
         if config_options:
@@ -355,21 +427,23 @@ def cloup_flow_opts(
                         dir_okay=True,
                     ),
                     is_eager=True,
-                    default=os.environ.pop("PDK_ROOT", None),
+                    envvar=["PDK_ROOT"],
                     help="Override Ciel PDK root folder. Required if Ciel is not installed, but a default value can also be set via the environment variable PDK_ROOT.",
                 ),
                 o(
                     "-p",
                     "--pdk",
                     type=str,
-                    default=os.environ.pop("PDK", "sky130A"),
+                    envvar=["PDK"],
+                    default="sky130A",
                     help="The process design kit to use.",
                 ),
                 o(
                     "-s",
                     "--scl",
                     type=str,
-                    default=os.environ.pop("STD_CELL_LIBRARY", None),
+                    envvar=["STD_CELL_LIBRARY"],
+                    # no default, default is obtained dynamically from PDK
                     help="The standard cell library to use. If None, the PDK's default standard cell library is used.",
                 ),
             )(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "3.0.0.dev34"
+version = "3.0.0.dev35"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
This PR rejects paths provided over the command line that start with a tilde, as it typically implies tilde expansion has failed. We considered the alternative of implementing tilde expansion ourselves, but given that LibreLane does not embed a shell (and that automatic tilde expansion may in fact be surprising for some people,) we elected to provide a *very* comprehensive error message instead:

```console
$ python3 -m librelane --pdk-root "~/.ciel"
Usage: python -m librelane [OPTIONS] [CONFIG_FILES]...
Try 'python -m librelane --help' for help.

Error: Invalid value for '--pdk-root': '~/.ciel' starts with a tilde, which is ambiguous.
  * If you meant your home directory, make sure your POSIX shell is able to expand the tilde:
    * GOOD: python -m librelane --pdk-root ~/.ciel   …
    * BAD:  python -m librelane --pdk-root=~/.ciel   …
    * BAD:  python -m librelane --pdk-root "~/.ciel" …
    * GOOD: PDK_ROOT=~/.ciel   python -m librelane …
    * BAD:  PDK_ROOT="~/.ciel" python -m librelane …
  * If you want a relative file or directory that starts with a literal "~", use an absolute path.
 ```

References:
* https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01

---

(Additionally, I've also reformatted the changelog for style consistency, this wasn't an issue before because I was the only person writing changelogs at Efabless but now that's no longer the case.)