### PR TITLE
docs: clean and improve `usage/timing_closure`

### DIFF
--- a/docs/source/usage/timing_closure/index.md
+++ b/docs/source/usage/timing_closure/index.md
@@ -417,7 +417,10 @@ The files `max.rpt` and `min.rpt` contain the timing reports for setup and hold
 constraint analysis (respectively) sorted by the slack (worst first). Here is
 one such example showing a timing path from the `max.rpt` report:
 
-```
+``` {code-block} text
+:caption: : Max slack report
+:name: max-rpt-log
+:class: no-lines-numbers
 Startpoint: x[9] (input port clocked by clk)
 Endpoint: _618_ (rising edge-triggered flip-flop clocked by clk)
 Path Group: clk
@@ -444,8 +447,7 @@ Delay Time Description
 ---------------------------------------------------------
 0.39 slack (MET)
 ```
-
-The report snippet above contains a timing report for one of the min
+The report snippet {ref}`above <max-rpt-log>` contains a timing report for one of the min
 timing paths. The report for any timing path is comprised of 4 sections:
 
 * The header: contains basic information about the timing path, such as the


### PR DESCRIPTION
## Description 

Update the [timing closure documentation](https://librelane.readthedocs.io/en/latest/usage/timing_closure/index.html), full list of changes : 
- add missing figure references
- add missing inline mathematical notation delimiters `$`
- remove duplicate text
- rework STA equations: 
  - specify setup and hold 
    - X_{s} -> X_{setup}
    - X_{h} -> X_{hold}
  - fix typo : equation 6 is for calculating hold slack, not setup slack
- add definition of acronym in text when they first appear
- add definition to acronyms : RAT
- update description of timing related configuration variables, tried to make it clearer if option impacts hold or setup time ( :warning: requesting review, might have missed something ) 
- `vios` -> `violations`
- add href to section 3

## Testing changes 

- [x] documentation has been generated locally and validated 
<img width="474" height="477" alt="image" src="https://github.com/user-attachments/assets/c3d05376-505d-4274-b49b-f06fef5296d0" />

## Note

I am purposefully segmenting unrelated documentation RPs for ease of review, please fell free to tell me if you would like any future PRs to be lumped into a single larger RP. 