### PR TITLE
feat: Magic.DRC: Make `DesignFormat.DEF` optional

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -54,9 +54,13 @@ Style Notes
 
   * Allowed values: "AddToCell", "OverwriteCell", "RenameCell" and "SkipNewCell"
 
-* `Magic.DRC`: Added `MAGIC_GDS_FLATGLOB`
+* `Magic.DRC`
 
-  * Used to flatten cells in order to prevent false positive DRC errors.
+  * Added `MAGIC_GDS_FLATGLOB`
+
+    * Used to flatten cells in order to prevent false positive DRC errors.
+
+  * Made `DesignFormat.DEF` optional
 
 * `Magic.SpiceExtraction`: Added `MAGIC_EXT_UNIQUE` to replace
   `MAGIC_NO_EXT_UNIQUE`
@@ -265,7 +269,8 @@ Style Notes
   * Added `LINTER_VLT` as a user defined Verilator Configuration format file
     (`.vlt`).
 
-  * Verilator now creates a `_waivers_output.vlt` file based on the encountered linter warnings.
+  * Verilator now creates a `_waivers_output.vlt` file based on the encountered
+    linter warnings.
 
 * `Yosys.*Synthesis`
 

--- a/librelane/steps/magic.py
+++ b/librelane/steps/magic.py
@@ -393,7 +393,7 @@ class DRC(MagicStep):
     name = "DRC"
     long_name = "Design Rule Checks"
 
-    inputs = [DesignFormat.DEF, DesignFormat.GDS]
+    inputs = [DesignFormat.DEF.mkOptional(), DesignFormat.GDS]
     outputs = []
 
     config_vars = MagicStep.config_vars + [
@@ -416,6 +416,10 @@ class DRC(MagicStep):
     def run(self, state_in: State, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
         reports_dir = os.path.join(self.step_dir, "reports")
         mkdirp(reports_dir)
+
+        # Check that the DEF exists if needed
+        if not self.config["MAGIC_DRC_USE_GDS"]:
+            assert state_in.get(DesignFormat.DEF)
 
         views_updates, metrics_updates = super().run(state_in, **kwargs)
 


### PR DESCRIPTION
This way it is possible to run magic DRC on a state that only contains the GDS.