### PR TITLE
feat: add `MAGIC_DRC_MAGLEFS` to blackbox cells during DRC

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -62,6 +62,10 @@ Style Notes
 
   * Made `DesignFormat.DEF` optional
 
+  * Added `MAGIC_DRC_MAGLEFS`
+
+    * Used to blackbox cells during DRC
+
 * `Magic.SpiceExtraction`: Added `MAGIC_EXT_UNIQUE` to replace
   `MAGIC_NO_EXT_UNIQUE`
 

--- a/librelane/scripts/magic/drc.tcl
+++ b/librelane/scripts/magic/drc.tcl
@@ -12,6 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+crashbackups disable
+
+# Read in maglef views in order to blackbox cells
+if { [info exists ::env(MAGIC_DRC_MAGLEFS)] } {
+    foreach {maglef} $::env(MAGIC_DRC_MAGLEFS) {
+        puts "Loading maglef view: $maglef"
+        load $maglef
+    }
+}
+
+# Enable gds noduplicates to ignore cells
+# that have been previously loaded as maglef
+gds noduplicates true
+gds readonly true
+
 # Flatten cells
 if { [info exists ::env(MAGIC_GDS_FLATGLOB)] } {
     foreach {gds_flatglob} $::env(MAGIC_GDS_FLATGLOB) {

--- a/librelane/steps/magic.py
+++ b/librelane/steps/magic.py
@@ -408,6 +408,11 @@ class DRC(MagicStep):
             Optional[List[str]],
             "Flatten cells by name pattern on input. May be used to avoid false positive DRC errors. The strings may use standard shell-type glob patterns, with * for any length string match, ? for any single character match, \\ for special characters, and [] for matching character sets or ranges.",
         ),
+        Variable(
+            "MAGIC_DRC_MAGLEFS",
+            Optional[List[Path]],
+            "A list of pre-processed abstract LEF views for cells. They are read in before the design and act as blackboxes during DRC."
+        ),
     ]
 
     def get_script_path(self):


### PR DESCRIPTION
This PR adds `MAGIC_DRC_MAGLEFS` to load a list of maglefs before reading the actual layout, in order to blackbox certain cells.

Note: There are already two existing variables as part of `MagicStep`: `CELL_MAGS` and `CELL_MAGLEFS`
However, those are only used as fallback for (blackboxed) cells. In addition, it seems their functionality **isn't implemented** anymore?

If so, we should either remove them, implement their functionality or merge them in some way with `MAGIC_DRC_MAGLEFS`.