### PR TITLE
container.py: allow docker to start when DISPLAY=remote.host.org:0

### DIFF
--- a/librelane/container.py
+++ b/librelane/container.py
@@ -57,10 +57,13 @@ def gui_args(osinfo: OSInfo) -> List[str]:
             args += [
                 "-e",
                 f"DISPLAY={os.environ.get('DISPLAY')}",
-                "-v",
-                "/tmp/.X11-unix:/tmp/.X11-unix",
-                "-v",
-                f"{os.path.expanduser('~')}/.Xauthority:/.Xauthority",
+            ]
+            if os.path.isdir("/tmp/.X11-unix"):
+                args += ["-v", "/tmp/.X11-unix:/tmp/.X11-unix"]
+            homedir = os.path.expanduser("~")
+            if os.path.isfile(f"{homedir}/.Xauthority"):
+                args += ["-v", f"{homedir}/.Xauthority:/.Xauthority"]
+            args += [
                 "--network",
                 "host",
                 "--security-opt",


### PR DESCRIPTION
Docker will fail to start if a --volume argument does not exist to mount.  It is completely possible to use X11 over a TCP network the '--network host' is already set to facilitate this.