### PR TITLE
Fix subprocess formatting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,13 @@
 ## Documentation
 -->
 
+# 2.4.8
+
+## Misc. Enhancements/Bugfixes
+
+* Change `strip()` on subprocess logs to `rstrip()` to prevent misformatting of
+  tables and other elements.
+
 # 2.4.7
 
 ## Documentation
@@ -66,8 +73,8 @@
 
 * Moved installation into its own separate section.
 * Codified API stability policy.
-* Updated Contributor's Guide with information about access control and
-  code ownership policy.
+* Updated Contributor's Guide with information about access control and code
+  ownership policy.
 * Updated `make docs` to only install dependencies if inside a venv.
 * Fixed all broken links.
 * Replaced nodemon with pymon.

--- a/librelane/steps/step.py
+++ b/librelane/steps/step.py
@@ -188,7 +188,7 @@ class DefaultOutputProcessor(OutputProcessor[Dict[str, Any]]):
             # and terminal emulators will slow the flow down.
             self.current_rpt.write(line)
         elif not self.silent:
-            logging.subprocess(line.strip())
+            logging.subprocess(line.rstrip())
         return True
 
     def result(self) -> Dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.7"
+version = "2.4.8"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
This PR fixes a long outstanding issue that has to do with the formatting of subprocess output.

Initially, I thought the change would be needed in the logger or Rich itself, but it turns out that the subprocess output was completely stripped of its whitespace ^^

This changes the call from `strip` to `rstrip`, as it still allows Rich to do a better formatting of the output if there is whitespace after the text, while keeping the formatting of tables and such.

Before:

<img width="500" alt="Bildschirmfoto vom 2025-11-19 17-49-25" src="https://github.com/user-attachments/assets/a711e7fa-0649-4ac9-852f-0dc944dbebec" />

After:

<img width="500" alt="Bildschirmfoto vom 2025-11-19 17-47-20" src="https://github.com/user-attachments/assets/fb27edc4-551b-47fe-babe-97fc715a3545" />

Fixes #791
