### PR TITLE
fix: set dont_touch around gpl

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -212,6 +212,8 @@ Style Notes
 
   * Corrected `GPL_CELL_PADDING` to be an integer.
 
+  * Enabled `dont_touch` around GPL as it does not prevent cell placement.
+
 * `OpenROAD.IOPlacement`
 
   * Added optional variable `IO_EXCLUDE_PIN_REGION`
@@ -432,6 +434,7 @@ Style Notes
     has failed. This is a compromise solution as tilde expansion within
     LibreLane itself would be POSIX-ly incorrect, yet, many users pass quoted
     tildes and then are surprised when it doesn't work.
+
     * Relative paths that start with a genuine tilde must be provided as
       absolute paths.
 
@@ -523,6 +526,7 @@ Style Notes
 ## Documentation
 
 * Variable types now link to dataclasses' API reference as appropriate.
+
 # 2.4.6
 
 ## Misc. Enhancements/Bugfixes
@@ -566,8 +570,8 @@ Style Notes
 
 * Moved installation into its own separate section.
 * Codified API stability policy.
-* Updated Contributor's Guide with information about access control and
-  code ownership policy.
+* Updated Contributor's Guide with information about access control and code
+  ownership policy.
 * Updated `make docs` to only install dependencies if inside a venv.
 * Fixed all broken links.
 * Replaced nodemon with pymon.

--- a/librelane/scripts/openroad/gpl.tcl
+++ b/librelane/scripts/openroad/gpl.tcl
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
+source $::env(SCRIPTS_DIR)/openroad/common/resizer.tcl
+
 read_current_odb
+
+set_dont_touch_objects
 
 set ::insts [$::block getInsts]
 
@@ -77,6 +81,7 @@ append_if_exists_argument arg_list PL_KEEP_RESIZE_BELOW_OVERFLOW -keep_resize_be
 
 log_cmd global_placement {*}$arg_list
 
+unset_dont_touch_objects
 
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
 estimate_parasitics -placement

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -1382,6 +1382,7 @@ class _GlobalPlacement(OpenROADStep):
     config_vars = (
         OpenROADStep.config_vars
         + routing_layer_variables
+        + rsz_variables
         + [
             Variable(
                 "PL_TARGET_DENSITY_PCT",


### PR DESCRIPTION
Enables `dont_touch` around GPL as it does not prevent cell placement.

Fixes #695