### PR TITLE
fix: remove misleading clock period substitution

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,19 @@
 ## Documentation
 -->
 
+# 2.4.11
+
+## Steps
+
+* `Yosys.*Synthesis`
+
+  * Removed misleading nonfunctional clock delay propagation to ABC scripts
+    pending further investigations.
+
+## Misc. Enhancements/Bugfixes
+
+* Fixed copyright information.
+
 # 2.4.10
 
 ## Misc. Enhancements/Bugfixes
@@ -33,7 +46,7 @@
 
 ## Misc. Enhancements/Bugfixes
 
-* Change `strip()` on subprocess logs to `rstrip()` to prevent misformatting of
+* Changed `strip()` on subprocess logs to `rstrip()` to prevent misformatting of
   tables and other elements.
 
 # 2.4.7

--- a/Readme.md
+++ b/Readme.md
@@ -14,10 +14,8 @@
 
 LibreLane is an ASIC infrastructure library based on several components including
 OpenROAD, Yosys, Magic, Netgen, CVC, KLayout and a number of custom scripts for
-design exploration and optimization, currently developed and maintained by
-members and affiliates of the
-[American University in Cairo Open Hardware Lab](https://github.com/aucohl)
-under the stewardship of the [FOSSi Foundation](https://fossi-foundation.org).
+design exploration and optimization, currently developed and maintained under
+the stewardship of the [FOSSi Foundation](https://fossi-foundation.org).
 
 A reference flow, "Classic", performs all ASIC implementation steps from RTL all
 the way down to GDSII.

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -14,9 +14,8 @@
 
 Originally started as version 2.0 of OpenLane, LibreLane is a piece of software
 for {term}`ASIC` implementation, initially developed by Efabless Corporation,
-but its currently maintained by the same developers at the
-[American University in Cairo Open Hardware Lab](https://github.com/aucohl)
-under the stewardship of the [FOSSi Foundation](https://fossi-foundation.org).
+but its currently maintained under the stewardship of the
+[FOSSi Foundation](https://fossi-foundation.org).
 
 Version 1.0 of OpenLane was a simple but stable and battle-tested flow, primarily
 intended for implementing  designs for Efabless's {term}`MPW` programs.
@@ -49,7 +48,8 @@ many other tools in order to achieve a full RTL-to-GDSII flow.
 OpenROAD is primarily developed by The OpenROAD Project, which involves many
 corporations and academic institutions (primarily the University of California,
 San Diego, Parallax Software, and Precision Innovations). LibreLane, on the
-other hand, was primarily developed at Efabless Corporation and is currently maintained by the American University in Cairo, Open Hardware Lab.
+other hand, was primarily developed at Efabless Corporation and is currently
+maintained by the community under the stewardship of the FOSSi Foundation.
 
 (faq-proprietary-pdks)=
 
@@ -78,7 +78,7 @@ shuttles since 3.5 and a number of internal tape-outs at Efabless Corporation.
 | Architecture | Monolithic | Plugin-based | Monolithic | Plugin-based |
 | Configuration | Tcl Files | Python Files | JSON/Tcl Files | JSON/Tcl/Python Files |
 | Programming Language | GNU Make | Python | Tcl | Type-checked Python |
-| Maintainer | The OpenROAD Project | ZeroASIC | Efabless | AUCOHL |
+| Maintainer | The OpenROAD Project | ZeroASIC | Efabless | FOSSi Foundation |
 | Dependencies | Separate (Build Scripts) | Separate (Build Scripts) | Bundled | Bundled  |
 | Cloud Service | No | Yes | No | No (Planned) |
 | Proprietary Tool Support | No | Yes | No | Yes (with Plugins) |

--- a/librelane/__main__.py
+++ b/librelane/__main__.py
@@ -205,8 +205,10 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool):
         f"""
         LibreLane v{__version__}
 
-        Copyright ©2020-2025 Efabless Corporation, The American University in
-        Cairo, and other contributors.
+        Copyright ©2025-2026 LibreLane Contributors
+
+        Adapted from OpenLane 2.0
+        Copyright ©2020-2025 Efabless Corporation
 
         Available under the Apache License, version 2. Included with the source code,
         but you can also get a copy at https://www.apache.org/licenses/LICENSE-2.0

--- a/librelane/scripts/pyosys/construct_abc_script.py
+++ b/librelane/scripts/pyosys/construct_abc_script.py
@@ -18,6 +18,8 @@ import re
 class ABCScriptCreator:
     def __init__(self, config):
         self.config = config
+        D = config["CLOCK_PERIOD"] * 1000  # ns -> ps
+        self.D = D
 
         self.rs_K = "resub -K "
         self.rs = "resub"
@@ -55,8 +57,8 @@ class ABCScriptCreator:
 
         self.map_old_area = "map -p -a -B 0.2 -A 0.9 -M 0"
         self.map_old_dly = "map -p -B 0.2 -A 0.9 -M 0"
-        self.retime_area = "retime {D} -M 5"
-        self.retime_dly = "retime {D} -M 6"
+        self.retime_area = "retime -M 5"
+        self.retime_dly = "retime -M 6"
         self.map_new_area = "amap -m -Q 0.1 -F 20 -A 20 -C 5000"
 
         if config["SYNTH_ABC_AREA_USE_NF"]:
@@ -71,11 +73,9 @@ class ABCScriptCreator:
             max_tr_arg = ""
             if self.max_transition != 0:
                 max_tr_arg = f" -S {self.max_transition}"
-            self.fine_tune = (
-                f"buffer -N {self.max_fanout}{max_tr_arg};upsize {{D}};dnsize {{D}}"
-            )
+            self.fine_tune = f"buffer -N {self.max_fanout}{max_tr_arg};upsize;dnsize"
         elif config["SYNTH_SIZING"]:
-            self.fine_tune = "upsize {D};dnsize {D}"
+            self.fine_tune = "upsize;dnsize"
 
     def generate_abc_script(self, step_dir, strategy):
         strategy_clean = re.sub(r"\s+", "_", strategy)
@@ -160,7 +160,7 @@ class ABCScriptCreator:
             else:
                 print(self.delay_mfs3, file=f)
 
-            print("retime {D}", file=f)
+            print("retime", file=f)
 
             # & space
             print("&get -n", file=f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.10"
+version = "2.4.11"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
According to https://github.com/YosysHQ/yosys/pull/4343#issuecomment-3294183055, Yosys does not substitute {D} for user ABC scripts and is likely being silently ignored.