### PR TITLE
fix: register the technology in klayout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,14 @@
 ## Documentation
 -->
 
+# 2.4.9
+
+## Steps
+
+* `KLayout.OpenGUI`
+
+  * Fixed the technology not being registered.
+
 # 2.4.8
 
 ## Misc. Enhancements/Bugfixes

--- a/librelane/scripts/klayout/open_design.py
+++ b/librelane/scripts/klayout/open_design.py
@@ -27,6 +27,13 @@ def open_design(input_lefs: Tuple[str, ...], lyt: str, lyp: str, lym: str, input
 
         tech = pya.Technology()
         tech.load(lyt)
+        # Register the technology.
+        # Throws an exception if a technology
+        # with the same name already exists.
+        try:
+            pya.Technology().register_technology(tech)
+        except Exception:
+            print(f"Could not register the technology: {tech.name}.")
 
         layout_options = tech.load_layout_options
         layout_options.keep_other_cells = True
@@ -35,7 +42,7 @@ def open_design(input_lefs: Tuple[str, ...], lyt: str, lyp: str, lym: str, input
         layout_options.lefdef_config.lef_files = list(input_lefs)
         layout_options.lefdef_config.map_file = lym
 
-        cell_view = main_window.load_layout(input, layout_options, 0)
+        cell_view = main_window.load_layout(input, layout_options, tech.name, False)
         layout_view = cell_view.view()
         layout_view.load_layer_props(lyp)
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "librelane"
-version = "2.4.8"
+version = "2.4.9"
 description = "An infrastructure for implementing chip design flows"
 # Technically, maintainer. We cannot use the maintainers field until
 # poetry-core>=2.0.0 which requires Python version 3.9+. This field does


### PR DESCRIPTION
This allows to use features such as the net tracer, if set up for the technology.