### PR TITLE
[STA] fmax metric support 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -203,6 +203,9 @@ Style Notes
 
   * Better error reporting for unexpected openroad failures.
 
+* `OpenROAD.STA*`
+  * Add Max Frequency metric for each corner to summart.rpt
+  
 * `OpenROAD.CTS`
 
   * Added flags `CTS_OBSTRUCTION_AWARE` and `CTS_BALANCE_LEVELS`

--- a/Changelog.md
+++ b/Changelog.md
@@ -204,7 +204,7 @@ Style Notes
   * Better error reporting for unexpected openroad failures.
 
 * `OpenROAD.STA*`
-  * Add Max Frequency metric for each corner to summart.rpt
+  * Add Max Frequency metric for each corner to summary.rpt
   
 * `OpenROAD.CTS`
 

--- a/librelane/common/metrics/library.py
+++ b/librelane/common/metrics/library.py
@@ -124,6 +124,12 @@ Metric(
 )
 
 Metric(
+    "fmax__clk",
+    aggregator=min_aggregator,
+    higher_is_better=True,
+)
+
+Metric(
     "timing__setup_r2r__ws",
     aggregator=min_aggregator,
     higher_is_better=True,

--- a/librelane/common/metrics/library.py
+++ b/librelane/common/metrics/library.py
@@ -124,7 +124,7 @@ Metric(
 )
 
 Metric(
-    "fmax__clk",
+    "timing__clock__fmax",
     aggregator=min_aggregator,
     higher_is_better=True,
 )

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -183,10 +183,10 @@ puts "\n========================================================================
 puts "Worst Slack (Setup)"
 puts "============================================================================"
 
-set ws [worst_slack -corner [$corner name] -max]
-write_metric_num "timing__setup__ws__corner:[$corner name]" $ws
+set ws [worst_slack -corner $corner_name -max]
+write_metric_num "timing__setup__ws__corner:$corner_name" $ws
 set w_s $ws
-puts "[$corner name]: $ws"
+puts "$corner_name: $ws"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT tns.min.rpt"
@@ -409,7 +409,7 @@ foreach clock [all_clocks] {
       set fmax [expr 1.0e3 / $min_period]
     }
     
-    write_metric_num "timing__clock__fmax__corner:[$corner name]" $fmax
+    write_metric_num "timing__clock__fmax__corner:$corner_name" $fmax
 }
 
 puts "%OL_END_REPORT"

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -403,10 +403,13 @@ foreach clock [all_clocks] {
     set min_period [expr $CLK_PERIOD-$w_s]
     if { $min_period == 0.0 } {
       set min_period 0
-      set fmax "INF"
+      set fmax_n "INF"
     } else {
       # max frequency in MHz
       set fmax [expr 1.0e3 / $min_period]
+      if {$w_s <0} {
+	      set fmax [expr {$fmax * -1.0}]
+      }
     }
     
     write_metric_num "timing__clock__fmax__corner:$corner_name" $fmax

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -183,9 +183,9 @@ puts "\n========================================================================
 puts "Worst Slack (Setup)"
 puts "============================================================================"
 
-set ws [worst_slack -corner $corner_name -max]
-write_metric_num "timing__setup__ws__corner:$corner_name" $ws
-puts "$corner_name: $ws"
+set w_s [worst_slack -corner [$corner name] -max]
+write_metric_num "timing__setup__ws__corner:[$corner name]" $w_s
+puts "[$corner name]: $ws"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT tns.min.rpt"
@@ -397,14 +397,15 @@ foreach clock [all_clocks] {
     puts "============================================================================"
     report_clock_min_period -clocks [get_property $clock name]
 
-    set include_port_paths [info exists flags(-include_port_paths)]
-    set min_period [sta::find_clk_min_period $clock $include_port_paths ]
+
+    set CLK_PERIOD [get_property $clock period]
+    set min_period [expr $CLK_PERIOD-$w_s]
     if { $min_period == 0.0 } {
       set min_period 0
       set fmax "INF"
     } else {
       # max frequency in MHz
-      set fmax [expr 1.0e-6 / $min_period]
+      set fmax [expr 1.0e3 / $min_period]
     }
     
     write_metric_num "fmax__clk__corner:[$corner name]" $fmax

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -396,6 +396,18 @@ foreach clock [all_clocks] {
     puts "report_clock_min_period"
     puts "============================================================================"
     report_clock_min_period -clocks [get_property $clock name]
+
+    set include_port_paths [info exists flags(-include_port_paths)]
+    set min_period [sta::find_clk_min_period $clock $include_port_paths ]
+    if { $min_period == 0.0 } {
+      set min_period 0
+      set fmax "INF"
+    } else {
+      # max frequency in MHz
+      set fmax [expr 1.0e-6 / $min_period]
+    }
+    
+    write_metric_num "fmax__clk__corner:[$corner name]" $fmax
 }
 
 puts "%OL_END_REPORT"

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -183,8 +183,9 @@ puts "\n========================================================================
 puts "Worst Slack (Setup)"
 puts "============================================================================"
 
-set w_s [worst_slack -corner [$corner name] -max]
-write_metric_num "timing__setup__ws__corner:[$corner name]" $w_s
+set ws [worst_slack -corner [$corner name] -max]
+write_metric_num "timing__setup__ws__corner:[$corner name]" $ws
+set w_s $ws
 puts "[$corner name]: $ws"
 puts "%OL_END_REPORT"
 
@@ -408,7 +409,7 @@ foreach clock [all_clocks] {
       set fmax [expr 1.0e3 / $min_period]
     }
     
-    write_metric_num "fmax__clk__corner:[$corner name]" $fmax
+    write_metric_num "timing__clock__fmax__corner:[$corner name]" $fmax
 }
 
 puts "%OL_END_REPORT"

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -870,7 +870,7 @@ class MultiCornerSTA(OpenSTAStep):
                 "timing__setup_r2r_vio__count",
                 "design__max_cap_violation__count",
                 "design__max_slew_violation__count",
-                "fmax__clk",
+                "timing__clock__fmax",
             ]:
                 formatter = format_count if metric.endswith("count") else format_slack
                 row.append(

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -870,6 +870,7 @@ class MultiCornerSTA(OpenSTAStep):
                 "timing__setup_r2r_vio__count",
                 "design__max_cap_violation__count",
                 "design__max_slew_violation__count",
+                "fmax__clk",
             ]:
                 formatter = format_count if metric.endswith("count") else format_slack
                 row.append(

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -849,6 +849,7 @@ class MultiCornerSTA(OpenSTAStep):
         table.add_column("of which reg to reg")
         table.add_column("Max Cap Violations")
         table.add_column("Max Slew Violations")
+        table.add_column("Max Frequency")
         for corner in ["Overall"] + self.config["STA_CORNERS"]:
             modifier = ""
             if corner != "Overall":


### PR DESCRIPTION
Resolves : #790 

- Added Metric for max clock frequency 

Hi @mole99 

To Add Multiple Clocks 

I can do at corner.tcl as 
  ```
      set index 0 
      for clk in all_clocks
          set fmax_lit "fmax_$index:[$corner name]"
           write_metrix_num $fmax_lit  $fmax
 ```

but i am not able to find a method in finding number of clocks at openroad.py 

eg : 
```
    for i in range(num_clocks)
          table.append(fmax_ + i)
```
   