### PR TITLE
feat!: create `final` directory even with deferred errors

### DIFF
--- a/librelane/flows/sequential.py
+++ b/librelane/flows/sequential.py
@@ -409,6 +409,6 @@ class SequentialFlow(Flow):
                 "One or more deferred errors were encountered:\n"
                 + "\n".join(deferred_errors)
             )
-        
+
         success("Flow complete.")
         return (current_state, step_list)


### PR DESCRIPTION
This might be considered a breaking change, but personally, I find it much more convenient to always have a final folder to look at metrics.json, even if a step failed.