### PR TITLE
fix: improve `from_magic_feedback` parsing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -513,6 +513,10 @@ Style Notes
   overriden by default. To match the old behavior as much as possible we now
   create the `PDN_MACRO_CONNECTIONS` before the SCL connections.
 
+* `from_magic_feedback`
+
+  * Added "-" to wordchars so that a string like "box 369787 -1 369789 1" would be correctly split.
+
 ## API Breaks
 
 * `CLI`

--- a/librelane/common/drc.py
+++ b/librelane/common/drc.py
@@ -225,6 +225,7 @@ class DRC:
         violations: Dict[str, Violation] = {}
         last_bounding_box: Optional[BoundingBox] = None
         lex = shlex.shlex(feedback.read(), posix=True)
+        lex.wordchars = lex.wordchars + "-"
         components = list(lex)
         while len(components):
             instruction = components.pop(0)


### PR DESCRIPTION
This PR adds "-" to the wordchars of shlex, so that a string like "box 369787 -1 369789 1" will be split into:

`['box', '369787', '-1', '369789', '1']`

and not:

`['box', '369787', '-', '1', '369789', '1']`