### PR TITLE
chore: update nix-eda + OpenROAD + OpenSTA

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -448,16 +448,16 @@ Style Notes
 
 * Python requirement bumped up to ≥3.10
   * Does not affect Nix users where Python 3.12 is used anyway.
-* Updated nix-eda to 6.0.1
+* Updated nix-eda to 6.4.0
   * Updated nixpkgs to nixos-25.11 (@ `b3aad46`)
-  * Updated KLayout to `0.30.4`
-  * Updated Magic to `8.3.581`
-  * Updated Netgen to `1.5.308`
-  * Updated Yosys to `0.60`
+  * Updated KLayout to `0.30.6`
+  * Updated Magic to `8.3.610`
+  * Updated Netgen to `1.5.316`
+  * Updated Yosys to `0.62`
     * Replaced Synlig with [Slang](https://github.com/povik/yosys-slang)
-  * Updated Verilator to `5.042`
-* Updated OpenROAD to `341650e`
-* Updated OpenSTA to `ffabd65`
+  * Updated Verilator to `5.044`
+* Updated OpenROAD to `dcf36133`
+* Updated OpenSTA to `857316ff`
 * Nix
   * `librelane` derivation:
     * Added new arguments `yosys-plugin-set` and `extra-yosys-plugins`

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764011051,
-        "narHash": "sha256-M7SZyPZiqZUR/EiiBJnmyUbOi5oE/03tCeFrTiUZchI=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "17ed8d9744ebe70424659b0ef74ad6d41fc87071",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -48,7 +48,7 @@
         "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "revCount": 69,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz?rev=ff81ac966bb2cae68946d5ed5fc4994f96d0ffec&revCount=69"
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -60,16 +60,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1768614091,
-        "narHash": "sha256-UElQINIEz44UlEXP9eIJmjMuCIkP9fS8+WitJwyTYzw=",
+        "lastModified": 1772293091,
+        "narHash": "sha256-x2TIO+FHH11UEY4n6751CCALpC7jFLP5PYZojjsVYtw=",
         "owner": "fossi-foundation",
         "repo": "nix-eda",
-        "rev": "8d6f4ea82716b59bc6eff6b070304e1b916b2c75",
+        "rev": "56e8e416eba07198d83f1f8dc819f9f1b99caf6d",
         "type": "github"
       },
       "original": {
         "owner": "fossi-foundation",
-        "ref": "6.0.2",
+        "ref": "6.4.0",
         "repo": "nix-eda",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   description = "open-source infrastructure for implementing chip design flows";
 
   inputs = {
-    nix-eda.url = "github:fossi-foundation/nix-eda/6.0.2";
+    nix-eda.url = "github:fossi-foundation/nix-eda/6.4.0";
     ciel.url = "github:fossi-foundation/ciel";
     devshell.url = "github:numtide/devshell";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";

--- a/librelane/scripts/magic/def/mag_gds.tcl
+++ b/librelane/scripts/magic/def/mag_gds.tcl
@@ -56,6 +56,8 @@ read_def
 load $::env(DESIGN_NAME)
 select top cell
 
+units microns
+
 if { $::env(MAGIC_ZEROIZE_ORIGIN) } {
 	# assuming scalegrid 1 2
 	# makes origin zero based on the minimum enclosing box
@@ -73,8 +75,7 @@ if { $::env(MAGIC_ZEROIZE_ORIGIN) } {
 	# file. Shapes can extend outside the block boundary.
 	# magic "lef write -hide" doesn't produce nice results in this
 	# case for shapes outside the boundary.
-	box [lindex $::env(DIE_AREA) 0]um [lindex $::env(DIE_AREA) 1]um [lindex $::env(DIE_AREA) 2]um [lindex $::env(DIE_AREA) 3]um
-	property FIXED_BBOX [box values]
+	property FIXED_BBOX [lindex $::env(DIE_AREA) 0]um [lindex $::env(DIE_AREA) 1]um [lindex $::env(DIE_AREA) 2]um [lindex $::env(DIE_AREA) 3]um
 }
 
 select top cell

--- a/nix/openroad.nix
+++ b/nix/openroad.nix
@@ -42,9 +42,9 @@
   openroad,
   buildPythonEnvForInterpreter,
   # top
-  rev ? "dfc4f595dfb2e1c346492ff1f0274abb28725acf",
-  rev-date ? "2026-01-06",
-  sha256 ? "sha256-CVsWiOIYJSei2ur7KPlFu5CfLv3CBhvVSnzoAcKJNhs=",
+  rev ? "a87f768cfc3ab085d5a170225fa61ed01a4c97e2",
+  rev-date ? "2026-02-17",
+  sha256 ? "sha256-NpGAMIICNwCtlbQP/Gu7UYyLOw5UpsCudCUEyp92fhI=",
   # tests tend to time out and fail, esp on Darwin. imperatively it's easy to
   # re-run them but in Nix it starts the long compile all over again.
   enableTesting ? false,

--- a/nix/openroad.nix
+++ b/nix/openroad.nix
@@ -42,9 +42,9 @@
   openroad,
   buildPythonEnvForInterpreter,
   # top
-  rev ? "a87f768cfc3ab085d5a170225fa61ed01a4c97e2",
+  rev ? "dcf36133a369abc8f3c5e5738cd4d82e4903c0e0",
   rev-date ? "2026-02-17",
-  sha256 ? "sha256-NpGAMIICNwCtlbQP/Gu7UYyLOw5UpsCudCUEyp92fhI=",
+  sha256 ? "sha256-E9UVTgCfr/k5DnbJ2H2w+wFAzr1eNfooVi1jj8Vz4w4=",
   # tests tend to time out and fail, esp on Darwin. imperatively it's easy to
   # re-run them but in Nix it starts the long compile all over again.
   enableTesting ? false,
@@ -55,7 +55,7 @@ let
     "-DTCL_LIBRARY=${tcl}/lib/libtcl${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DTCL_HEADER=${tcl}/include/tcl.h"
     "-DUSE_SYSTEM_BOOST:BOOL=ON"
-    "-DCMAKE_CXX_FLAGS=-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED=1 -I${eigen}/include/eigen3 ${lib.strings.optionalString debug "-g -O0"}"
+    "-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations -DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED=1 -I${eigen}/include/eigen3 ${lib.strings.optionalString debug "-g -O0"}"
     "-DCUDD_LIB=${cudd}/lib/libcudd.a"
   ];
   join_flags = lib.strings.concatMapStrings (x: " \"${x}\" ");

--- a/nix/opensta.nix
+++ b/nix/opensta.nix
@@ -16,9 +16,9 @@
   cudd,
   zlib,
   eigen,
-  rev ? "9c9b5659d6a7ecbe02ea1204aa89079a77db1d3e",
-  rev-date ? "2025-12-02",
-  sha256 ? "sha256-VjIK6puJ9/9yevjRHx7bxyCmFjoH6cW6U3cze052nmo=",
+  rev ? "857316ff001b2a8dbbdc5996944d08a6d38c87ab",
+  rev-date ? "2026-02-14",
+  sha256 ? "sha256-4lxyNQeBTx+bIEM4RVZzG4UU/ilv9sjFFUcB5S4Evgw=",
 }:
 clangStdenv.mkDerivation (finalAttrs: {
   name = "opensta";

--- a/nix/opensta.nix
+++ b/nix/opensta.nix
@@ -16,6 +16,7 @@
   cudd,
   zlib,
   eigen,
+  ninja,
   rev ? "857316ff001b2a8dbbdc5996944d08a6d38c87ab",
   rev-date ? "2026-02-14",
   sha256 ? "sha256-4lxyNQeBTx+bIEM4RVZzG4UU/ilv9sjFFUcB5S4Evgw=",
@@ -85,6 +86,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     gnumake
     flex
     bison
+    ninja
   ];
 
   meta = {


### PR DESCRIPTION
This PR updates nix-eda, OpenROAD and OpenSTA.

I haven't updated OpenROAD and OpenSTA to the latest versions because OpenSTA is undergoing major changes for multi-mode support.