### PR TITLE
magic: use readspice before extraction

### DIFF
--- a/librelane/scripts/magic/common/read.tcl
+++ b/librelane/scripts/magic/common/read.tcl
@@ -144,6 +144,7 @@ proc read_def {} {
     if { $::env(MAGIC_DEF_LABELS) } {
         lappend def_read_args -labels
     }
+    load \(UNNAMED\)
     puts "> def read $def_read_args"
     def read {*}$def_read_args
 }

--- a/librelane/scripts/magic/common/read.tcl
+++ b/librelane/scripts/magic/common/read.tcl
@@ -147,3 +147,11 @@ proc read_def {} {
     puts "> def read $def_read_args"
     def read {*}$def_read_args
 }
+
+proc read_pdk_spice {} {
+    set spice_files_in $::env(CELL_SPICE_MODELS)
+    foreach spice_file $spice_files_in {
+        puts "> spice read $spice_file"
+        readspice $spice_file
+    }
+}

--- a/librelane/scripts/magic/extract_spice.tcl
+++ b/librelane/scripts/magic/extract_spice.tcl
@@ -25,6 +25,7 @@ if { $::env(MAGIC_EXT_USE_GDS) } {
     source $::env(SCRIPTS_DIR)/magic/common/read.tcl
     read_tech_lef
     read_pdk_lef
+    read_pdk_spice
     read_macro_lef
     read_extra_lef
     read_pad_lef


### PR DESCRIPTION
To match the port order of the spice subckts when extracting from the layout we need to first read the spice models.