### PR TITLE
CI: add magic-nix-cache and optional fork docker push to GHCR

### DIFF
--- a/.github/actions/setup_nix/action.yml
+++ b/.github/actions/setup_nix/action.yml
@@ -39,6 +39,8 @@ runs:
           access-tokens = ${{ env.GITHUB_ACCESS_TOKEN_STR }}
           extra-substituters = ${{ env.EXTRA_SUBSTITUTER_STR }} https://nix-cache.fossi-foundation.org
           extra-trusted-public-keys = ${{ env.EXTRA_TRUSTED_KEY_STR }} nix-cache.fossi-foundation.org:3+K59iFwXqKsL7BNu6Guy0v+uTlwsxYQxjspXzqLYQs=
+    - name: Enable magic-nix-cache (GitHub Actions cache as Nix binary cache)
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Inject GitHub Token into Environment
       if: inputs.github_token != ''
       uses: fossi-foundation/nix-eda/.github/actions/nix_daemon_inject_github_token@5.5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,8 @@ jobs:
     runs-on: ${{ matrix.os.runner }}
     needs: [build-linux-x86_64, build-linux-aarch64]
     name: Build Docker Image (${{ matrix.os.arch }})
+    permissions:
+      packages: write
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v5
@@ -372,6 +374,12 @@ jobs:
         with:
           name: docker-image-${{ matrix.os.arch }}
           path: ${{ env.IMAGE_PATH }}
+      - name: Push to GHCR (fork builds)
+        if: vars.FORK_DOCKER_PUSH == 'true'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker tag librelane:tmp-${{ matrix.os.nix }} ghcr.io/${{ github.repository }}:dev-${{ matrix.os.arch }}
+          docker push ghcr.io/${{ github.repository }}:dev-${{ matrix.os.arch }}
   test-containers:
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Add `DeterminateSystems/magic-nix-cache-action` to `setup_nix`, using GitHub Actions cache as a Nix binary cache. This speeds up Nix builds by caching store paths between runs without requiring external infrastructure (no secrets needed).
- Add optional docker image push to GHCR in the `build-docker` job, gated on the repository variable `FORK_DOCKER_PUSH`. Disabled by default — enable on forks via Settings > Variables > `FORK_DOCKER_PUSH = true`. Uses `GITHUB_TOKEN` for auth (scoped to the fork's own GHCR namespace, e.g. `ghcr.io/robtaylor/librelane:dev-x86_64`).

## Test plan
- [ ] Verify magic-nix-cache doesn't interfere with existing S3 cache (both are additive substituters)
- [ ] Verify `build-docker` job still uploads artifacts when `FORK_DOCKER_PUSH` is unset
- [ ] On a fork with `FORK_DOCKER_PUSH=true`, verify images are pushed to `ghcr.io/<fork>/librelane:dev-{x86_64,aarch64}`