### PR TITLE
feat: add support for non-default rules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -199,6 +199,7 @@ Style Notes
   * Made `CTS_SINK_CLUSTERING_SIZE` and `CTS_SINK_CLUSTERING_MAX_DIAMETER`
     optional. OpenROAD determines the best values.
   * Added `CTS_MACRO_CLUSTERING_SIZE` and `CTS_MACRO_CLUSTERING_MAX_DIAMETER`.
+  * Added `CTS_APPLY_NDR` to set the non-default rule strategy.
 
 * `OpenROAD.CutRows`
 
@@ -221,6 +222,8 @@ Style Notes
     considered instead.
   * Added `DRT_ANTENNA_REPAIR_JUMPER_ONLY`.
   * Added `DRT_ANTENNA_REPAIR_DIODE_ONLY`.
+  * Added `NON_DEFAULT_RULES` to specify non-default rules.
+  * Added `DRT_ASSIGN_NDR` to assign nets to non-default rules.
 
 * Created `OpenROAD.DumpRCValues`
 

--- a/librelane/scripts/openroad/cts.tcl
+++ b/librelane/scripts/openroad/cts.tcl
@@ -72,6 +72,7 @@ append_if_exists_argument arg_list CTS_MACRO_CLUSTERING_MAX_DIAMETER -macro_clus
 append_if_flag arg_list CTS_DISABLE_POST_PROCESSING -post_cts_disable
 append_if_flag arg_list CTS_OBSTRUCTION_AWARE -obstruction_aware
 append_if_flag arg_list CTS_BALANCE_LEVELS -balance_levels
+append_if_exists_argument arg_list CTS_APPLY_NDR -apply_ndr
 
 if { $::env(CTS_DISTANCE_BETWEEN_BUFFERS) != 0 } {
     lappend arg_list -distance_between_buffers $::env(CTS_DISTANCE_BETWEEN_BUFFERS)


### PR DESCRIPTION
This PR adds support for using non-default rules. This can be useful if you want to route non-critical analog nets.

* `OpenROAD.CTS`
  * Added `CTS_APPLY_NDR` to set the non-default rule strategy.

* `OpenROAD.DetailedRouting`
  * Added `NON_DEFAULT_RULES` to specify non-default rules.
  * Added `DRT_ASSIGN_NDR` to assign nets to non-default rules.