### PR TITLE
docs: document appimages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,10 +719,7 @@ jobs:
           generate_release_notes: true
           body: |+
             📖 Installation instructions: https://librelane.readthedocs.io/en/latest/installation/index.html
-            🧾 Full changelog: ${{ github.server_url }}/${{ github.repository }}/blob/${{ env.NEW_TAG }}/Changelog.md
-
-            AppImage releases are provided for testing and are not currently the
-            primary supported method for installation.
+            🧾 Changelog: ${{ github.server_url }}/${{ github.repository }}/blob/${{ env.NEW_TAG }}/Changelog.md
 
             ---
 

--- a/docs/source/installation/appimage_installation/_common.md
+++ b/docs/source/installation/appimage_installation/_common.md
@@ -1,0 +1,14 @@
+# Entering the LibreLane Environment
+
+From your terminal, simply type `~/librelane-devshell-$(uname -m).AppImage`.
+
+Your prompt should now look kind of like this:
+
+```console
+[nix-shell:~]$ 
+```
+
+That's it! You are now inside the LibreLane environment and can run any of the
+included tools.
+
+You can test that LibreLane works correctly by running `librelane --smoke-test`.

--- a/docs/source/installation/appimage_installation/index.md
+++ b/docs/source/installation/appimage_installation/index.md
@@ -1,0 +1,17 @@
+# AppImage Installation
+
+```{tip}
+On Windows, you can use the Windows Subsystem for Linux, which we provide
+instructions for below.
+
+On macOS, you will need a virtual machine solution of some kind. We recommend
+[lima](https://lima-vm.io), but we recommend {ref}`nix-based-installation` to
+take full advantage of your hardware.
+```
+
+```{toctree}
+:glob:
+:maxdepth: 1
+installation_win
+installation_linux
+```

--- a/docs/source/installation/appimage_installation/installation_linux.md
+++ b/docs/source/installation/appimage_installation/installation_linux.md
@@ -1,0 +1,43 @@
+# Linux
+
+* **Minimum Requirements**
+    * Quad-core CPU running at 2.0 GHz+
+    * 8 GiB of RAM
+    
+* **Recommended Requirements**
+    * 6th Gen Intel® Core CPU or later OR AMD Ryzen™ 1000-series or later
+    * 16 GiB of RAM
+
+For Ubuntu, only 22.04 and above are officially supported.
+
+```{include} ../_ubuntu_packages.md
+:heading-offset: 1
+```
+
+## Downloading the LibreLane AppImage
+
+Download the latest release from
+<https://github.com/librelane/librelane/releases/latest> using your browser.
+
+Most people should download `librelane-devshell-x86_64.AppImage`, but those on
+ARM-based computers should download `librelane-devshell-aarch64.AppImage`.
+
+In a terminal, do the following:
+
+1. Move the downloaded AppImage to your home directory, e.g.:
+
+    ```console
+    $ mv ~/Downloads/librelane-devshell-$(uname -m).AppImage ~
+    ```
+
+1. Give execution permissions for the LibreLane AppImage:
+
+    ```console
+    $ chmod a+x ~/librelane-devshell-$(uname -m).AppImage
+    ```
+
+
+```{include} _common.md
+:heading-offset: 1
+
+```

--- a/docs/source/installation/appimage_installation/installation_win.md
+++ b/docs/source/installation/appimage_installation/installation_win.md
@@ -1,0 +1,43 @@
+# Windows 10+
+
+* **Minimum Requirements**
+    * Windows 10 version 2004 (Build 19041 and higher)
+    * Quad-core CPU running at 2.0 GHz+
+    * 8 GiB of RAM
+    
+* **Recommended**
+    * Windows 11
+    * 6th Gen Intel® Core CPU or later OR AMD Ryzen™️ 1000-series or later
+    * 16 GiB of RAM
+
+```{include} ../wsl/_common.md
+:heading-offset: 1
+:relative-images:
+```
+
+## Downloading the LibreLane AppImage
+
+Download the latest release from
+<https://github.com/librelane/librelane/releases/latest> using your browser.
+
+Most people should download `librelane-devshell-x86_64.AppImage`, but those on
+ARM-based computers should download `librelane-devshell-aarch64.AppImage`.
+
+Inside WSL, do the following:
+
+1. Move the downloaded AppImage from the Windows filesystem to the Linux
+   filesystem as follows:
+
+    ```console
+    $ mv /mnt/c/Users/*/Downloads/librelane-devshell-$(uname -m).AppImage ~
+    ```
+
+1. Give execution permissions for the LibreLane AppImage:
+
+    ```console
+    $ chmod a+x ~/librelane-devshell-$(uname -m).AppImage
+    ```
+
+```{include} _common.md
+:heading-offset: 1
+```

--- a/docs/source/installation/docker_installation/installation_macos.md
+++ b/docs/source/installation/docker_installation/installation_macos.md
@@ -1,12 +1,16 @@
-# macOS 11+
+# macOS 14+
+
+```{note}
+macOS 12 and 13 may work, but they are not officially supported.
+```
 
 * **Minimum Requirements**
-    * macOS 11 (Big Sur)
+    * macOS 14 (Sonoma)
     * 6th Gen Intel® Core CPU or later
     * 16 GiB of RAM
     
 * **Recommended**
-    * macOS 11 (Big Sur)
+    * macOS 14 (Sonoma)
     * Apple Silicon CPU
     * 32 GiB of RAM
 

--- a/docs/source/installation/docker_installation/installation_ubuntu.md
+++ b/docs/source/installation/docker_installation/installation_ubuntu.md
@@ -5,7 +5,7 @@
     * 8 GiB of RAM
     
 * **Recommended Requirements**
-    * 6th Gen Intel® Core CPU or later OR AMD Ryzen™️ 1000-series or later
+    * 6th Gen Intel® Core CPU or later OR AMD Ryzen™ 1000-series or later
     * 16 GiB of RAM
 
 Only Ubuntu 22.04 and above are supported.

--- a/docs/source/installation/index.md
+++ b/docs/source/installation/index.md
@@ -1,43 +1,52 @@
 # Installation
 
-LibreLane offers two primary methods of installation: using **Nix** and using
-**Docker**.
+There are a number of ways to install LibreLane on your Windows, Mac, or Linux
+computer.
 
-## Nix (Recommended)
+## Nix (Best)
 
 Nix is a build system for Linux and macOS allowing for _cachable_ and
 _reproducible_ builds, and is the primary build system for LibreLane.
 
-Compared to the Docker method, Nix offers:
+Compared to the other methods, Nix offers:
 
-* **Native Execution on macOS:** LibreLane is built natively for both Intel and
-  Apple Silicon-based Macs, unlike Docker which uses a Virtual Machine, and
-  thus requires more resources.
-* **Filesystem integration:** No need to worry about which folders are being
-  mounted like in the Docker containers- Nix apps run natively in your userspace.
 * **Smaller deltas:** if one tool is updated, you do not need to re-download
-  everything, which is not the case with Docker.
+  everything, which is not the case with the AppImage and Docker.
 * **Dead-simple customization:** You can modify any tool versions and/or any
   LibreLane code and all you need to do is re-invoke `nix-shell`. Nix's smart
   cache-substitution feature will automatically figure out whether your build is
   cached or not, and if not, will automatically attempt to build any tools that
   have been changed.
-
+* **Native Execution on macOS:** LibreLane is built natively for both Intel and
+  Apple Silicon-based Macs, unlike the AppImage or Docker which would use a
+  Virtual Machine, and thus requires more resources.
+  
 Because of the advantages afforded by Nix, we recommend trying to install using
-Nix first. Follow the installation guide here:
-{ref}`nix-based-installation`
+Nix. Follow the installation guide here: {ref}`nix-based-installation`.
 
-## Docker (Alternative)
+## AppImage (Easiest)
+
+If you're on Linux or are willing to use the Windows Subsystem for Linux (WSL),
+the easiest way to get up and running with LibreLane is by downloading an
+[AppImage](https://appimage.org) of LibreLane, which is a single-file download
+that requires no further installation, but does not work in certain environments
+such as inside Docker containers.
+
+Follow the installation guide here: `doc`{/installation/appimage_installation/index}.
+
+## Docker
 
 Docker containers offer:
 
-* Support for Windows, Mac and Linux on both `x86-64` and `aarch64`
-* **Sandboxing:** A completely different environment for using LibreLane
-* **Familiarity:** Users of previous versions of LibreLane will already have
-  Docker installed
+* Support for Windows, Mac and Linux on both `x86-64` and `aarch64`.
+* **Sandboxing:** A completely different environment for using LibreLane, where
+  you can choose which directories to expose to LibreLane.
+* **Familiarity:** Users of OpenLane will already have Docker installed.
 
-If Nix doesn't work for you for whatever reason, you may want to try Docker.
-Follow the installation guide here: {doc}`/installation/docker_installation/index`.
+If both the AppImage and Nix don't work for you for whatever reason, you may
+want to try Docker. Follow the installation guide here:
+{doc}`/installation/docker_installation/index`.
+
 ## Other Options
 
 You may elect to somehow provide the tools yourself. Here is a non-exhaustive
@@ -59,5 +68,6 @@ some incompatibilities may arise, and we will not be able to support them.
 :maxdepth: 2
 
 nix_installation/index
+appimage_installation/index
 docker_installation/index
 ```

--- a/docs/source/installation/nix_installation/installation_linux.md
+++ b/docs/source/installation/nix_installation/installation_linux.md
@@ -30,7 +30,7 @@ $ sudo apt-get install -y curl
 After that, simply run this command:
 
 ```console
-$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --prefer-upstream-nix --no-confirm --extra-conf "
+$ curl --proto '=https' --tlsv1.2 -fsSL https://artifacts.nixos.org/nix-installer | sh -s -- install --no-confirm --extra-conf "
     extra-substituters = https://nix-cache.fossi-foundation.org
     extra-trusted-public-keys = nix-cache.fossi-foundation.org:3+K59iFwXqKsL7BNu6Guy0v+uTlwsxYQxjspXzqLYQs=
 "

--- a/docs/source/installation/nix_installation/installation_macos.md
+++ b/docs/source/installation/nix_installation/installation_macos.md
@@ -1,13 +1,17 @@
-# macOS 11+
+# macOS 14+
+
+```{note}
+macOS 12 and 13 may work, but they are not officially supported.
+```
 
 * **Minimum Requirements**
-    * macOS 11 (Big Sur)
+    * macOS 14 (Sonoma)
     * 4th Gen Intel® Core CPU or later
     * 8 GiB of RAM
     
 * **Recommended**
-    * macOS 11 (Big Sur)
-    * Apple Silicon CPU
+    * macOS 14 (Sonoma)
+    * Apple M1 or later
     * 16 GiB of RAM
 
 ## Installing Nix
@@ -15,7 +19,7 @@
 Simply run this (entire) command in `Terminal.app`:
 
 ```console
-$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --prefer-upstream-nix --no-confirm --extra-conf "
+$ curl --proto '=https' --tlsv1.2 -fsSL https://artifacts.nixos.org/nix-installer | sh -s -- install--no-confirm --extra-conf "
     extra-substituters = https://nix-cache.fossi-foundation.org
     extra-trusted-public-keys = nix-cache.fossi-foundation.org:3+K59iFwXqKsL7BNu6Guy0v+uTlwsxYQxjspXzqLYQs=
 "

--- a/docs/source/installation/nix_installation/installation_win.md
+++ b/docs/source/installation/nix_installation/installation_win.md
@@ -10,38 +10,10 @@
     * 6th Gen Intel® Core CPU or later OR AMD Ryzen™️ 1000-series or later
     * 16 GiB of RAM
 
-## Setting up WSL
-
-1. Follow [official Microsoft documentation for WSL located here](https://docs.microsoft.com/en-us/windows/wsl/install) to install the WSL 2.
-
-
-```{note}
-LibreLane *requires* WSL2. Make sure that you're using Windows 11, or
-Windows 10 is up-to-date.
+```{include} ../wsl/_common.md
+:heading-offset: 1
+:relative-images:
 ```
-
-1. If you have an installation of WSL2 from 2023 or earlier, follow [Microsoft's official documention to enable `systemd`](https://learn.microsoft.com/en-us/windows/wsl/systemd)
-    * `systemd` is enabled by default for installations of WSL2 from mid-2023 or later.
-
-1. Click the Windows icon, type in "Windows PowerShell" and open it.
-
-    ![The Windows 11 Start Menu with "powershell" typed into the search box, showing "Windows PowerShell" as the first match](../wsl/powershell.webp)
-
-1. Install Ubuntu using the following command: `wsl --install -d Ubuntu`
-
-1. Check the version of WSL using following command: `wsl --list --verbose`
-
-    It should produce the following output:
-
-    ```powershell
-    PS C:\Users\user> wsl --list --verbose
-    NAME                   STATE           VERSION
-    * Ubuntu                 Running         2
-    ```
-
-1. Launch "Ubuntu" from your Start Menu.
-
-    ![The Windows 11 Start Menu showing a search for the "Ubuntu" app, next to which is a window of the Windows Terminal which opens after clicking it](../wsl/wsl.webp)
 
 ## Installing Nix
 
@@ -59,7 +31,7 @@ $ sudo apt-get install -y curl
 Then install Nix by running the following command:
 
 ```console 
-$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --prefer-upstream-nix --no-confirm --extra-conf "
+$ curl --proto '=https' --tlsv1.2 -fsSL https://artifacts.nixos.org/nix-installer | sh -s -- install --no-confirm --extra-conf "
     extra-substituters = https://nix-cache.fossi-foundation.org
     extra-trusted-public-keys = nix-cache.fossi-foundation.org:3+K59iFwXqKsL7BNu6Guy0v+uTlwsxYQxjspXzqLYQs=
 "

--- a/docs/source/installation/wsl/_common.md
+++ b/docs/source/installation/wsl/_common.md
@@ -1,0 +1,32 @@
+# Setting up WSL
+
+1. Follow [official Microsoft documentation for WSL located here](https://docs.microsoft.com/en-us/windows/wsl/install) to install the WSL 2.
+
+
+```{note}
+LibreLane *requires* WSL2. Make sure that you're using Windows 11, or
+Windows 10 is up-to-date.
+```
+
+1. If you have an installation of WSL2 from 2023 or earlier, follow [Microsoft's official documention to enable `systemd`](https://learn.microsoft.com/en-us/windows/wsl/systemd)
+    * `systemd` is enabled by default for installations of WSL2 from mid-2023 or later.
+
+1. Click the Windows icon, type in "Windows PowerShell" and open it.
+
+    ![The Windows 11 Start Menu with "powershell" typed into the search box, showing "Windows PowerShell" as the first match](./powershell.webp)
+
+1. Install Ubuntu using the following command: `wsl --install -d Ubuntu`
+
+1. Check the version of WSL using following command: `wsl --list --verbose`
+
+    It should produce the following output:
+
+    ```powershell
+    PS C:\Users\user> wsl --list --verbose
+    NAME                   STATE           VERSION
+    * Ubuntu                 Running         2
+    ```
+
+1. Launch "Ubuntu" from your Start Menu.
+
+    ![The Windows 11 Start Menu showing a search for the "Ubuntu" app, next to which is a window of the Windows Terminal which opens after clicking it](./wsl.webp)

--- a/librelane/steps/step.py
+++ b/librelane/steps/step.py
@@ -670,10 +670,8 @@ class Step(ABC):
             for input, output in zip_longest(Self.inputs, Self.outputs):
                 input_str = ""
                 if input is not None:
-                    optional = "?" if input.value.optional else ""
-                    input_str = (
-                        f"{input.value.name}{optional} (.{input.value.extension})"
-                    )
+                    optional = "?" if input.optional else ""
+                    input_str = f"{input.id}{optional} (.{input.extension})"
 
                 output_str = ""
                 if output is not None:


### PR DESCRIPTION
Marks AppImages as a installation candidate and provides instructions for both Linux and WSL.

Also fixes usage of some deprecated methods in Step.get_help_md.