### PR TITLE
Corrected the procedures for the macro hardening guide

### DIFF
--- a/docs/source/usage/caravel/index.md
+++ b/docs/source/usage/caravel/index.md
@@ -140,6 +140,13 @@ ______________________________________________________________________
    $ mkdir -p ~/caravel_aes_accelerator/librelane/aes_wb_wrapper
    ```
 
+1. After hardening the `aes` macro, a script will be used for copying the physical views of the macro to a specified project folder, this script is in the `openlane` directory but not in the `librelane` directory, copy this script into the correct directory and replace the keyword 'openlane' to 'liberlane'
+
+   ```console
+   $ cp ~/caravel_aes_accelerator/openlane/copy_views.sh ~/caravel_aes_accelerator/librelane/copy_views.sh
+   $ sed -i 's/openlane/librelane/g' ~/caravel_aes_accelerator/librelane/copy_views.sh
+   ```
+
 1. Create the file
    `~/caravel_aes_accelerator/librelane/aes_wb_wrapper/config.json` and add the
    following simple configuration to it

--- a/docs/source/usage/caravel/index.md
+++ b/docs/source/usage/caravel/index.md
@@ -814,8 +814,17 @@ our design. To be able to use any design as a Caravel User Project, it has to
 match the footprint that Caravel is expecting. Also, the top-level design
 Caravel is expecting any Caravel User Project to have the IO pins at specific
 locations and with specific dimensions. So, we need a fixed floorplan, fixed
-I/Os pin shapes and locations, and fixed power rings. The fixed configuration
-section can be found at the end of the configurations file
+I/Os pin shapes and locations, and fixed power rings. 
+
+1. The provided configuration files can be found in `openlane/user_project_wrapper`
+   directory, therefore they need to be copied to the `librelane/user_project_wrapper`
+   directory:
+
+```console
+$ cp -r ~/caravel_aes_accelerator/openlane/user_project_wrapper/ ~/caravel_aes_accelerator/librelane/user_project_wrapper/
+```
+
+A fixed configuration section can be found at the end of the configurations file
 `librelane/user_project_wrapper/config.json`:
 
 ```json


### PR DESCRIPTION
In the steps for macro hardening, there are some necessary scripts and files in 'openlane' directory but not in 'librelane' directory, this pull request provides the instructions on how to copy those files and update them to work in the 'librelane' directory. If there are ways to update and add said files to the 'librelane' directory directly, it should be done and these instructions can be ignored.