### PR TITLE
chore: bump nix-eda to 6.7.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -449,10 +449,10 @@ Style Notes
 
 * Python requirement bumped up to ≥3.10
   * Does not affect Nix users where Python 3.12 is used anyway.
-* Updated nix-eda to 6.5.0
+* Updated nix-eda to 6.7.0
   * Updated nixpkgs to nixos-25.11 (@ `b3aad46`)
   * Updated KLayout to `0.30.6`
-  * Updated Magic to `8.3.613`
+  * Updated Magic to `8.3.615`
   * Updated Netgen to `1.5.316`
   * Updated Yosys to `0.62`
     * Replaced Synlig with [Slang](https://github.com/povik/yosys-slang)

--- a/flake.lock
+++ b/flake.lock
@@ -60,16 +60,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772639720,
-        "narHash": "sha256-KkfPpENVHu9/WAMJaIzUZCZVV3tzz1shw/shey9cC3M=",
+        "lastModified": 1772785985,
+        "narHash": "sha256-gYb69Nljd23/dxVFI7ckYLNJsZzLg38IcnlCSK9o6w8=",
         "owner": "fossi-foundation",
         "repo": "nix-eda",
-        "rev": "bd012d6fd62325dfc44528dcfd6d6f82e3a929e8",
+        "rev": "f089e7f2b2937d4943e2731c16d250d91ba4783b",
         "type": "github"
       },
       "original": {
         "owner": "fossi-foundation",
-        "ref": "6.5.0",
+        "ref": "6.7.0",
         "repo": "nix-eda",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   description = "open-source infrastructure for implementing chip design flows";
 
   inputs = {
-    nix-eda.url = "github:fossi-foundation/nix-eda/6.5.0";
+    nix-eda.url = "github:fossi-foundation/nix-eda/6.7.0";
     ciel.url = "github:fossi-foundation/ciel";
     devshell.url = "github:numtide/devshell";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";


### PR DESCRIPTION
to pull in magic update to 8.3.615