### PR TITLE
fix: reproducibles not working, drt snapshots

### DIFF
--- a/docs/source/usage/using_ecos.md
+++ b/docs/source/usage/using_ecos.md
@@ -74,8 +74,8 @@ endmodule
 ```
 
 Here, the clock for `u_ff2` is delayed, forcing a hold violation into existence.
-In a more realistic scenario, the resizer will invariably fix something so
-simple, but for the sake of demonstration, let's just turn it off.
+In a more realistic scenario, the resizer will usually be able to fix something
+so simple, but for the sake of demonstration, let's just turn it off.
 
 So running this config:
 

--- a/librelane/scripts/openroad/drt.tcl
+++ b/librelane/scripts/openroad/drt.tcl
@@ -76,7 +76,7 @@ set drc_report_iter_step_arg ""
 if { $::env(DRT_SAVE_SNAPSHOTS) } {
     set_debug_level DRT snapshot 1
     set drc_report_iter_step_arg "-drc_report_iter_step 1"
-    detailed_route_debug -snapshot_dir "$::env(STEP_DIR)/$directory"
+    detailed_route_debug -snapshot_dir "$::env(STEP_DIR)"
 }
 if { [info exists ::env(DRT_SAVE_DRC_REPORT_ITERS)] } {
     set drc_report_iter_step_arg "-drc_report_iter_step $::env(DRT_SAVE_DRC_REPORT_ITERS)"

--- a/librelane/steps/__main__.py
+++ b/librelane/steps/__main__.py
@@ -122,9 +122,10 @@ o = partial(option, show_default=True)
     sequential_flow_controls=False,
     jobs=False,
     accept_config_files=False,
+    pdk_options=False,
 )
 @pass_context
-def run(ctx, output, state_in, config, id, pdk_root, pdk, scl):
+def run(ctx, output, state_in, config, id, pdk_root):
     """
     Runs a step using a step-specific configuration object and an input state.
 

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -457,7 +457,6 @@ class OpenROADStep(TclStep):
             command,
             env=env,
             check=check,
-            cwd=self.step_dir,
             **kwargs,
         )
 
@@ -1945,7 +1944,7 @@ class DetailedRouting(OpenROADStep):
             Variable(
                 "DRT_SAVE_SNAPSHOTS",
                 bool,
-                "This is an experimental variable. Saves an odb snapshot of the layout each routing iteration. This generates multiple odb files increasing disk usage.",
+                "Experimental: saves an odb snapshot of the layout each routing iteration. This increases disk usage considerably but is useful for debugging.",
                 default=False,
             ),
             Variable(


### PR DESCRIPTION
- update reproducible `@cloup_flow_opts` to not accept pdk options as they are unused
- openroad steps no longer run with the step directory as their cwd
  - was only required because earlier versions of openroad didn't support a drt snapshot directory
  - breaks reproducibles
- fixed botched DRT snapshot directory use in #702