### PR TITLE
chore: opensta 3 compatibility (without updating tool)

### DIFF
--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -1,4 +1,4 @@
-# Copyright 2025 LibreLane Contributors
+# Copyright 2025-2026 LibreLane Contributors
 #
 # Adapted from OpenLane
 #
@@ -17,6 +17,49 @@
 # limitations under the License.
 source $::env(_TCL_ENV_IN)
 source $::env(SCRIPTS_DIR)/openroad/common/set_global_connections.tcl
+
+namespace eval lln {
+    proc get_corner_names {} {
+        # returns: names as a Tcl list, compatible with both OpenSTA 2 and 3
+        if {[string length [namespace which sta::scenes]] != 0} {
+            # scenes are bridged as a list of strings
+            return [sta::scenes]
+        } else {
+            # corners are not bridged as strings
+            set result [list]
+            foreach corner [sta::corners] {
+                lappend result [$corner name]
+            }
+            return $result
+        }
+    }
+    proc get_corner_dict {} {
+        # returns: Tcl dictionary from corner names to whatever object is
+        # interpreted as a corner for internal commands that expect corners:
+        # - in OpenSTA 3, that's the scene's name again
+        # - in OpenSTA 2, that's an opaque Tcl pointer
+        set result [dict create]
+        if {[string length [namespace which sta::scenes]] != 0} {
+            foreach scene [sta::scenes] {
+                dict set result $scene $scene
+            }
+        } else {
+            foreach corner [sta::corners] {
+                dict set result [$corner name] $corner
+            }
+        }
+        return $result
+    }
+
+    proc set_sta_cmd_corner {corner_name} {
+        if {[string length [namespace which sta::set_cmd_scene]] != 0} {
+            sta::set_cmd_scene $corner_name
+        } else {
+            set corner_object [sta::find_corner $corner_name]
+            sta::set_cmd_corner $corner_object
+        }
+    }
+};
 
 proc string_in_file {file_path substring} {
     set f [open $file_path r]
@@ -532,9 +575,7 @@ proc write_views {args} {
     }
 
     if { [info exists ::env(SAVE_SDF)] } {
-        set corners [sta::corners]
-        if { [llength $corners] > 1 } {
-        } else {
+        if { [llength [lln::get_corner_names]] <= 1 } {
             puts "Writing SDF to '$::env(SAVE_SDF)'…"
             write_sdf -include_typ -divider . $::env(SAVE_SDF)
         }
@@ -543,11 +584,8 @@ proc write_views {args} {
 
 proc write_sdfs {} {
     if { [info exists ::env(_SDF_SAVE_DIR)] } {
-        set corners [sta::corners]
-
         puts "Writing SDF files for all corners…"
-        foreach corner $corners {
-            set corner_name [$corner name]
+        foreach corner_name [lln::get_corner_names] {
             set target $::env(_SDF_SAVE_DIR)/$::env(DESIGN_NAME)__$corner_name.sdf
             write_sdf -include_typ -divider . -corner $corner_name $target
         }
@@ -560,10 +598,8 @@ proc write_libs {} {
         # This is to avoid OpenSTA writing a context-dependent timing model
         set_clock_latency -source -max 0 [all_clocks]
         set_clock_latency -source -min 0 [all_clocks]
-        set corners [sta::corners]
         puts "Writing timing models for all corners…"
-        foreach corner $corners {
-            set corner_name [$corner name]
+        foreach corner_name [lln::get_corner_names] {
             set target $::env(_LIB_SAVE_DIR)/$::env(DESIGN_NAME)__$corner_name.lib
             puts "Writing timing models for the $corner_name corner to $target…"
             write_timing_model -corner $corner_name $target

--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 LibreLane Contributors
+# Copyright 2025 LibreLane Contributors
 #
 # Adapted from OpenLane
 #

--- a/librelane/scripts/openroad/common/set_rc.tcl
+++ b/librelane/scripts/openroad/common/set_rc.tcl
@@ -24,7 +24,7 @@ proc log_cmd_rc {cmd args} {
 }
 
 proc set_layers_custom_rc {args} {
-    # Returns: All corners for which RC values were found
+    # Returns: All corner names for which RC values were found
     set i "0"
     set tc_key "_LAYER_RC_$i"
     set custom_corner_rc [list]
@@ -41,9 +41,8 @@ proc set_layers_custom_rc {args} {
             -resistance $res_value
         incr i
         set tc_key "_LAYER_RC_$i"
-        set corner [sta::find_corner $corner_name]
-        if { [lsearch $custom_corner_rc $corner] == -1 } {
-            lappend custom_corner_rc $corner
+        if { [lsearch $custom_corner_rc $corner_name] == -1 } {
+            lappend custom_corner_rc $corner_name
         }
     }
     return $custom_corner_rc
@@ -63,9 +62,8 @@ proc set_via_custom_r {args} {
             -corner $corner_name
         incr i
         set tc_key "_VIA_R_$i"
-        set corner [sta::find_corner $corner_name]
-        if { [lsearch $custom_corner_r $corner] == -1 } {
-            lappend custom_corner_r $corner
+        if { [lsearch $custom_corner_r $corner_name] == -1 } {
+            lappend custom_corner_r $corner_name
         }
     }
     return $custom_corner_r
@@ -77,7 +75,7 @@ proc set_layers_default_rc {corners} {
         lassign [est::dblayer_wire_rc $layer] layer_wire_res_ohm_m layer_wire_cap_farad_m
         set layer_wire_res_per_unit_distance [expr $layer_wire_res_ohm_m * [sta::unit_scale distance] / [sta::unit_scale resistance]]
         set layer_wire_cap_per_unit_distance [expr $layer_wire_cap_farad_m * [sta::unit_scale distance] / [sta::unit_scale capacitance]]
-        foreach corner "$corners" {
+        foreach corner $corners {
             log_cmd_rc set_layer_rc \
                 -layer $layer_name\
                 -corner $corner\
@@ -132,9 +130,9 @@ proc set_wire_rc_wrapper {args} {
     }
 
     if { [info exists flags(-use_corners)] } {
-        foreach corner [sta::corners] {
-            log_cmd_rc set_wire_rc {*}$clock_args -corner [$corner name]
-            log_cmd_rc set_wire_rc {*}$signal_args -corner [$corner name]
+        foreach corner [lln::get_corner_names] {
+            log_cmd_rc set_wire_rc {*}$clock_args -corner $corner
+            log_cmd_rc set_wire_rc {*}$signal_args -corner $corner
         }
     } else {
         log_cmd_rc set_wire_rc {*}$clock_args
@@ -163,8 +161,8 @@ proc set_diff {setA setB} {
 
 set corners_with_custom_layer_rc [set_layers_custom_rc]
 set corners_with_custom_via_r [set_via_custom_r]
-set corners_without_custom_layer_rc [set_diff [sta::corners] $corners_with_custom_layer_rc]
-set corners_without_custom_via_r [set_diff [sta::corners] $corners_with_custom_via_r]
+set corners_without_custom_layer_rc [set_diff [lln::get_corner_names] $corners_with_custom_layer_rc]
+set corners_without_custom_via_r [set_diff [lln::get_corner_names] $corners_with_custom_via_r]
 
 # If ANY CORNERS have custom RC values set, set the tech LEF values for the
 # remaining corners.
@@ -175,7 +173,7 @@ set corners_without_custom_via_r [set_diff [sta::corners] $corners_with_custom_v
 # This is because, technically, while both behaviors SHOULD be identical, they
 # aren't because of roundoff errors emblematic of IEEE 754.
 if { [llength $corners_with_custom_layer_rc] } {
-    log_cmd_rc set_layers_default_rc [lmap corner $corners_without_custom_layer_rc "\$corner name"]
+    log_cmd_rc set_layers_default_rc $corners_without_custom_layer_rc
 }
 if { [llength $corners_with_custom_via_r] } {
     log_cmd_rc set_vias_default_r $corners_without_custom_via_r

--- a/librelane/scripts/openroad/dump_rc.tcl
+++ b/librelane/scripts/openroad/dump_rc.tcl
@@ -1,3 +1,7 @@
+# Copyright 2026 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2020-2022 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,8 +67,8 @@ proc resizer_rc_values {header} {
     upvar 1 r_entry r_entry
 
     puts $header
-    foreach corner [sta::corners] {
-        puts "=== Corner [$corner name] ==="
+    foreach {corner_name corner} [lln::get_corner_dict] {
+        puts "=== Corner $corner_name ==="
         puts "==== Estimation RC Values ===="
         puts [format $rc_header "Name" "Direction" "Res/Unit Distance" "Cap/Unit Distance"]
         puts [format $rc_entry "Signal" "Avg" [scale_ohm_per_meter [est::wire_signal_resistance $corner]] [scale_f_per_meter [est::wire_signal_capacitance $corner]]]

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -1,3 +1,7 @@
+# Copyright 2026 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2020-2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +17,8 @@
 # limitations under the License.
 
 # This file supports one defined corner per-process.
-# Any more defined corners will be ignored.
-# Aggregation is left to the LibreLane step.
+# Any more defined corners will be ignored: aggregation is left to the LibreLane
+# step.
 
 
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
@@ -44,8 +48,11 @@ if { [namespace exists ::ord] } {
 }
 read_spefs
 
-set corner [lindex [sta::corners] 0]
-sta::set_cmd_corner $corner
+foreach {corner_name corner_object} [lln::get_corner_dict] {
+    # the two variables above are set for the rest of this script's scope
+    lln::set_sta_cmd_corner $corner_name
+    break
+}
 
 set clocks [sta::sort_by_name [sta::all_clocks]]
 
@@ -57,8 +64,8 @@ puts "%OL_CREATE_REPORT min.rpt"
 puts "\n==========================================================================="
 puts "report_checks -path_delay min (Hold)"
 puts "============================================================================"
-puts "======================= [$corner name] Corner ===================================\n"
-report_checks -sort_by_slack -path_delay min -fields {slew cap input net fanout} -format full_clock_expanded -group_path_count 1000 -corner [$corner name]
+puts "======================= $corner_name Corner ===================================\n"
+report_checks -sort_by_slack -path_delay min -fields {slew cap input net fanout} -format full_clock_expanded -group_path_count 1000 -corner $corner_name
 puts ""
 puts "%OL_END_REPORT"
 
@@ -67,8 +74,8 @@ puts "%OL_CREATE_REPORT max.rpt"
 puts "\n==========================================================================="
 puts "report_checks -path_delay max (Setup)"
 puts "============================================================================"
-puts "======================= [$corner name] Corner ===================================\n"
-report_checks -sort_by_slack -path_delay max -fields {slew cap input net fanout} -format full_clock_expanded -group_path_count 1000 -corner [$corner name]
+puts "======================= $corner_name Corner ===================================\n"
+report_checks -sort_by_slack -path_delay max -fields {slew cap input net fanout} -format full_clock_expanded -group_path_count 1000 -corner $corner_name
 puts ""
 puts "%OL_END_REPORT"
 
@@ -77,23 +84,23 @@ puts "%OL_CREATE_REPORT checks.rpt"
 puts "\n==========================================================================="
 puts "report_checks -unconstrained"
 puts "==========================================================================="
-puts "======================= [$corner name] Corner ===================================\n"
-report_checks -unconstrained -fields {slew cap input net fanout} -format full_clock_expanded -corner [$corner name]
+puts "======================= $corner_name Corner ===================================\n"
+report_checks -unconstrained -fields {slew cap input net fanout} -format full_clock_expanded -corner $corner_name
 puts ""
 
 
 puts "\n==========================================================================="
 puts "report_checks --slack_max -0.01"
 puts "============================================================================"
-puts "======================= [$corner name] Corner ===================================\n"
-report_checks -slack_max -0.01 -fields {slew cap input net fanout} -format full_clock_expanded -corner [$corner name]
+puts "======================= $corner_name Corner ===================================\n"
+report_checks -slack_max -0.01 -fields {slew cap input net fanout} -format full_clock_expanded -corner $corner_name
 puts ""
 
 puts "\n==========================================================================="
 puts " report_check_types -max_slew -max_cap -max_fanout -violators"
 puts "============================================================================"
-puts "======================= [$corner name] Corner ===================================\n"
-report_check_types -max_slew -max_capacitance -max_fanout -violators -corner [$corner name]
+puts "======================= $corner_name Corner ===================================\n"
+report_check_types -max_slew -max_capacitance -max_fanout -violators -corner $corner_name
 puts ""
 
 puts "\n==========================================================================="
@@ -103,11 +110,11 @@ report_parasitic_annotation -report_unannotated
 
 puts "\n==========================================================================="
 puts "max slew violation count [sta::max_slew_violation_count]"
-write_metric_int "design__max_slew_violation__count__corner:[$corner name]" [sta::max_slew_violation_count]
+write_metric_int "design__max_slew_violation__count__corner:$corner_name" [sta::max_slew_violation_count]
 puts "max fanout violation count [sta::max_fanout_violation_count]"
-write_metric_int "design__max_fanout_violation__count__corner:[$corner name]" [sta::max_fanout_violation_count]
+write_metric_int "design__max_fanout_violation__count__corner:$corner_name" [sta::max_fanout_violation_count]
 puts "max cap violation count [sta::max_capacitance_violation_count]"
-write_metric_int "design__max_cap_violation__count__corner:[$corner name]" [sta::max_capacitance_violation_count]
+write_metric_int "design__max_cap_violation__count__corner:$corner_name" [sta::max_capacitance_violation_count]
 puts "============================================================================"
 
 puts "\n==========================================================================="
@@ -122,10 +129,10 @@ puts "%OL_CREATE_REPORT power.rpt"
 puts "\n==========================================================================="
 puts " report_power"
 puts "============================================================================"
-puts "======================= [$corner name] Corner ===================================\n"
-report_power -corner [$corner name]
+puts "======================= $corner_name Corner ===================================\n"
+report_power -corner $corner_name
 
-set power_result [sta::design_power $corner]
+set power_result [sta::design_power $corner_object]
 set totals       [lrange $power_result  0  3]
 lassign $totals design_internal design_switching design_leakage design_total
 
@@ -143,10 +150,10 @@ puts "\n========================================================================
 puts "Clock Skew (Hold)"
 puts "============================================================================"
 set skew_corner [worst_clock_skew -hold]
-write_metric_num "clock__skew__worst_hold__corner:[$corner name]" $skew_corner
+write_metric_num "clock__skew__worst_hold__corner:$corner_name" $skew_corner
 
-puts "======================= [$corner name] Corner ===================================\n"
-report_clock_skew -corner [$corner name] -hold
+puts "======================= $corner_name Corner ===================================\n"
+report_clock_skew -corner $corner_name -hold
 
 puts "%OL_END_REPORT"
 
@@ -155,10 +162,10 @@ puts "\n========================================================================
 puts "Clock Skew (Setup)"
 puts "============================================================================"
 set skew_corner [worst_clock_skew -setup]
-write_metric_num "clock__skew__worst_setup__corner:[$corner name]" $skew_corner
+write_metric_num "clock__skew__worst_setup__corner:$corner_name" $skew_corner
 
-puts "======================= [$corner name] Corner ===================================\n"
-report_clock_skew -corner [$corner name] -setup
+puts "======================= $corner_name Corner ===================================\n"
+report_clock_skew -corner $corner_name -setup
 
 puts "%OL_END_REPORT"
 
@@ -166,9 +173,9 @@ puts "%OL_CREATE_REPORT ws.min.rpt"
 puts "\n==========================================================================="
 puts "Worst Slack (Hold)"
 puts "============================================================================"
-set ws [worst_slack -corner [$corner name] -min]
-write_metric_num "timing__hold__ws__corner:[$corner name]" $ws
-puts "[$corner name]: $ws"
+set ws [worst_slack -corner $corner_name -min]
+write_metric_num "timing__hold__ws__corner:$corner_name" $ws
+puts "$corner_name: $ws"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT ws.max.rpt"
@@ -176,9 +183,9 @@ puts "\n========================================================================
 puts "Worst Slack (Setup)"
 puts "============================================================================"
 
-set ws [worst_slack -corner [$corner name] -max]
-write_metric_num "timing__setup__ws__corner:[$corner name]" $ws
-puts "[$corner name]: $ws"
+set ws [worst_slack -corner $corner_name -max]
+write_metric_num "timing__setup__ws__corner:$corner_name" $ws
+puts "$corner_name: $ws"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT tns.min.rpt"
@@ -186,18 +193,18 @@ puts "\n========================================================================
 puts "Total Negative Slack (Hold)"
 puts "============================================================================"
 
-set tns [total_negative_slack -corner [$corner name] -min]
-write_metric_num "timing__hold__tns__corner:[$corner name]" $tns
-puts "[$corner name]: $tns"
+set tns [total_negative_slack -corner $corner_name -min]
+write_metric_num "timing__hold__tns__corner:$corner_name" $tns
+puts "$corner_name: $tns"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT tns.max.rpt"
 puts "\n==========================================================================="
 puts "Total Negative Slack (Setup)"
 puts "============================================================================"
-set tns [total_negative_slack -corner [$corner name] -max]
-write_metric_num "timing__setup__tns__corner:[$corner name]" $tns
-puts "[$corner name]: $tns"
+set tns [total_negative_slack -corner $corner_name -max]
+write_metric_num "timing__setup__tns__corner:$corner_name" $tns
+puts "$corner_name: $tns"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT wns.min.rpt"
@@ -205,13 +212,13 @@ puts "\n========================================================================
 puts "Worst Negative Slack (Hold)"
 puts "============================================================================"
 
-set ws [worst_slack -corner [$corner name] -min]
+set ws [worst_slack -corner $corner_name -min]
 set wns 0
 if { $ws < 0 } {
     set wns $ws
 }
-write_metric_num "timing__hold__wns__corner:[$corner name]" $wns
-puts "[$corner name]: $wns"
+write_metric_num "timing__hold__wns__corner:$corner_name" $wns
+puts "$corner_name: $wns"
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT wns.max.rpt"
@@ -219,13 +226,13 @@ puts "\n========================================================================
 puts "Worst Negative Slack (Setup)"
 puts "============================================================================"
 
-set ws [worst_slack -corner [$corner name] -max]
+set ws [worst_slack -corner $corner_name -max]
 set wns 0.0
 if { $ws < 0 } {
     set wns $ws
 }
-write_metric_num "timing__setup__wns__corner:[$corner name]" $wns
-puts "[$corner name]: $wns"
+write_metric_num "timing__setup__wns__corner:$corner_name" $wns
+puts "$corner_name: $wns"
 puts "%OL_END_REPORT"
 
 proc check_if_terminal {pin_object} {
@@ -333,12 +340,12 @@ foreach path $setup_paths {
     }
 }
 
-write_metric_int "timing__hold_vio__count__corner:[$corner name]" $total_hold_vios
-write_metric_num "timing__hold_r2r__ws__corner:[$corner name]" $worst_r2r_hold_slack
-write_metric_int "timing__hold_r2r_vio__count__corner:[$corner name]" $r2r_hold_vios
-write_metric_int "timing__setup_vio__count__corner:[$corner name]" $total_setup_vios
-write_metric_num "timing__setup_r2r__ws__corner:[$corner name]" $worst_r2r_setup_slack
-write_metric_int "timing__setup_r2r_vio__count__corner:[$corner name]" $r2r_setup_vios
+write_metric_int "timing__hold_vio__count__corner:$corner_name" $total_hold_vios
+write_metric_num "timing__hold_r2r__ws__corner:$corner_name" $worst_r2r_hold_slack
+write_metric_int "timing__hold_r2r_vio__count__corner:$corner_name" $r2r_hold_vios
+write_metric_int "timing__setup_vio__count__corner:$corner_name" $total_setup_vios
+write_metric_num "timing__setup_r2r__ws__corner:$corner_name" $worst_r2r_setup_slack
+write_metric_int "timing__setup_r2r_vio__count__corner:$corner_name" $r2r_setup_vios
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT unpropagated.rpt"


### PR DESCRIPTION
- update io.tcl to create lln::get_corner_names, lln::get_corner_dict, and lln::set_sta_cmd_corner that abstract away whether opensta 2 or 3 is being used (or a corresponding version of openroad)
- rewrite dump_rc.tcl, set_rc.tcl, and corner.tcl to use said new functions

---

It's my hope that longer term, the `lln` Tcl namespace can include intuitive functions that users' custom OpenROAD steps can utilize. This is a good time to start it as any.