### PR TITLE
feat!: remove "readable_paths" from preprocessor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -543,6 +543,9 @@ Style Notes
 
   * `pdk_compat` set some compatibility values only if necessary.
 
+  * `refg::`, `dir::`, `pdk_dir::` now support globs outside the PDK directory
+    and the config directory.
+
 * `librelane.state`
 
   * `DesignFormat`

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -163,12 +163,11 @@ If the files you choose lie **inside** the design directory, a different prefix,
 `refg::`, supports non-recursive globs, i.e., you can use an asterisk as a
 wildcard to pick multiple files in a specific folder.
 
-* Outside the design directory, this is disabled for security reasons and the
-  final path will continue to include the asterisk.
-* `refg::` will always return an array, even if only one element was found, for
-  consistency.
-  * If no elements were found, the glob string is returned verbatim as a single
-    element in array.
+```{note}
+`refg::` will always return an array, even if only one element was found, for
+consistency. If no elements were found, the glob string is returned verbatim as
+a single element in array.
+```
 
 As shown below, `refg::$DESIGN_DIR/src/*.v` would find all files ending with
 `.v` in the `src` folder inside the design directory.

--- a/librelane/config/config.py
+++ b/librelane/config/config.py
@@ -707,12 +707,6 @@ class Config(GenericImmutableDict[str, Any]):
             if pdk_root is not None:
                 pdkpath = os.path.join(pdk_root, mutable["PDK"])
 
-        readable_paths = [
-            os.path.abspath(design_dir),
-        ]
-        if pdkpath != "":
-            readable_paths.append(os.path.abspath(pdkpath))
-
         mutable.update(
             preprocess_dict(
                 raw,
@@ -721,7 +715,6 @@ class Config(GenericImmutableDict[str, Any]):
                 scl=mutable[SpecialKeys.scl],
                 pad=mutable.get(SpecialKeys.pad, None),
                 design_dir=design_dir,
-                readable_paths=readable_paths,
             )
         )
 

--- a/librelane/config/preprocessor.py
+++ b/librelane/config/preprocessor.py
@@ -214,7 +214,6 @@ ref_rx = re.compile(r"^\$([A-Za-z_][A-Za-z0-9_\.\[\]]*)")
 def process_string(
     value: str,
     symbols: Mapping[str, Any],
-    readable_paths: Optional[List[str]] = None,
 ) -> Valid:
     global ref_rx
     EXPR_PREFIX = "expr::"
@@ -271,22 +270,12 @@ def process_string(
 
         ## If we're refg, all returns beyond this point must be of type
         ## List[str]
-
-        # Glob only if readable_paths isn't null
-        if readable_paths is None:
-            return [target]
-
         final_abspath = os.path.abspath(concatenated)
 
         # Glob only if it doesn't already resolve to a valid file
         if os.path.exists(final_abspath):
             return [final_abspath]
 
-        in_exposed = [final_abspath.startswith(p) for p in readable_paths]
-        if True not in in_exposed:
-            raise PermissionError(
-                f"'{concatenated}' is not located any path readable to LibreLane"
-            )
         files = sorted(glob.glob(final_abspath))
         files_escaped = [file.replace("$", r"\$") for file in files]
         files_escaped.sort()
@@ -307,7 +296,6 @@ def process_list_recursive(
     input: Sequence[Any],
     ref: List[Any],
     symbols: Dict[str, Any],
-    readable_paths: Optional[List[str]],
     *,
     key_path: str = "",
 ):
@@ -320,7 +308,6 @@ def process_list_recursive(
                 value,
                 processed,
                 symbols,
-                readable_paths,
                 key_path=current_key_path,
             )
         elif isinstance(value, Sequence) and not is_string(value):
@@ -329,11 +316,10 @@ def process_list_recursive(
                 value,
                 processed,
                 symbols,
-                readable_paths,
                 key_path=current_key_path,
             )
         elif is_string(value):
-            processed = process_string(value, symbols, readable_paths)
+            processed = process_string(value, symbols)
         else:
             processed = value
 
@@ -346,7 +332,6 @@ def process_dict_recursive(
     input: Mapping[str, Any],
     ref: Dict[str, Any],
     symbols: Dict[str, Any],
-    readable_paths: Optional[List[str]],
     *,
     key_path: str = "",
 ):
@@ -363,7 +348,6 @@ def process_dict_recursive(
                         value,
                         ref,
                         symbols,
-                        readable_paths,
                         key_path=key_path,
                     )
             elif key.startswith(SCL_PREFIX):
@@ -375,7 +359,6 @@ def process_dict_recursive(
                         value,
                         ref,
                         symbols,
-                        readable_paths,
                         key_path=key_path,
                     )
             else:
@@ -384,7 +367,6 @@ def process_dict_recursive(
                     value,
                     processed,
                     symbols,
-                    readable_paths,
                     key_path=current_key_path,
                 )
 
@@ -394,11 +376,10 @@ def process_dict_recursive(
                 value,
                 processed,
                 symbols,
-                readable_paths,
                 key_path=current_key_path,
             )
         elif is_string(value):
-            processed = process_string(value, symbols, readable_paths)
+            processed = process_string(value, symbols)
         else:
             processed = value
 
@@ -410,11 +391,10 @@ def process_dict_recursive(
 def process_config_dict(
     config_in: Mapping[str, Any],
     exposed_variables: Dict[str, Any],
-    readable_paths: Optional[List[str]],
 ) -> Dict[str, Any]:
     state = dict(exposed_variables)
     symbols = dict(exposed_variables)
-    process_dict_recursive(config_in, state, symbols, readable_paths)
+    process_dict_recursive(config_in, state, symbols)
     return state
 
 
@@ -434,11 +414,7 @@ def preprocess_dict(
     pdkpath: Optional[str] = None,
     scl: Optional[str] = None,
     pad: Optional[str] = None,
-    readable_paths: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
-    """
-    If readable_paths are set to None, refg:: will not work
-    """
     if None in (pdk, pdkpath, scl):
         if only_extract_process_info:
             pdkpath = ""
@@ -460,7 +436,6 @@ def preprocess_dict(
     preprocessed = process_config_dict(
         config_dict,
         base_vars,
-        readable_paths,
     )
     if only_extract_process_info:
         preprocessed = extract_process_vars(preprocessed)

--- a/librelane/scripts/openroad/grt.tcl
+++ b/librelane/scripts/openroad/grt.tcl
@@ -19,11 +19,6 @@ set_propagated_clock [all_clocks]
 
 source $::env(SCRIPTS_DIR)/openroad/common/grt.tcl
 
-# Check Antennas (Pre-Repair)
-puts "%OL_CREATE_REPORT antenna.rpt"
-check_antennas -verbose
-puts "%OL_END_REPORT"
-
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
 estimate_parasitics -global_routing
 

--- a/test/config/test_preprocessor.py
+++ b/test/config/test_preprocessor.py
@@ -66,36 +66,21 @@ def test_process_string():
     with pytest.raises(KeyError, match="not found"):
         process_string("ref::$A", {})
 
-    assert process_string(
-        "refg::$DESIGN_DIR/src/a*.v",
-        {"DESIGN_DIR": "/cwd"},
-        ["/cwd"],
-    ) == [
+    assert process_string("refg::$DESIGN_DIR/src/a*.v", {"DESIGN_DIR": "/cwd"}) == [
         "/cwd/src/a_file.v",
         "/cwd/src/another_file.v",
     ], "refg:: in design dir not working"
 
     assert process_string(
-        "refg::$DESIGN_DIR/src/a*.v",
-        {"DESIGN_DIR": "/cwd"},
-        ["/cwd"],
+        "refg::$DESIGN_DIR/src/a*.v", {"DESIGN_DIR": "/cwd"}
     ) == process_string(
-        "dir::src/a*.v",
-        {"DESIGN_DIR": "/cwd"},
-        ["/cwd"],
+        "dir::src/a*.v", {"DESIGN_DIR": "/cwd"}
     ), "dir:: doesn't match refg::$DESIGN_DIR"
 
-    with pytest.raises(PermissionError, match="readable to"):
-        process_string(
-            "refg::$MY_VARIABLE/src/a*.v",
-            {"DESIGN_DIR": "/cwd", "MY_VARIABLE": "/ncwd"},
-            ["/cwd"],
-        )
-
-    assert process_string("refg::$A/*", {"A": "B"}, ["/cwd"]) == [
+    assert process_string("refg::$A/*", {"A": "B"}) == [
         "B/*"
     ], "refg:: on non-existent directory not working"
-    assert process_string("refg::$A", {"A": "B"}, ["/cwd"]) == [
+    assert process_string("refg::$A", {"A": "B"}) == [
         "B"
     ], "refg:: without asterisks or ? did not return the same file path"
 
@@ -151,7 +136,6 @@ def test_preprocess_dict():
         pdk="sky130A",
         pdkpath="/cwd",
         scl="sky130_fd_sc_hd",
-        readable_paths=["/cwd"],
     )
     expected = {
         "PDK": "sky130A",


### PR DESCRIPTION
This makes refg:: (and by extension dir:: and pdk_dir::) work even outside the design and PDK directory.

This "feature" was initially done because remote execution was earlier in the roadmap back when the project was OpenLane 2 and it was thought this would enhance security by not allowing users to glob arbitrary directories in remote machines. But it's annoying and confusing users: we'll cross the bridge of securing LibreLane when we get to it. At the moment the Tcl-based files are a much easier point of attack anyway.

(I also removed a redundant antenna check in grt.tcl because it takes time for some designs and is repeated immediately after the next step.)