### PR TITLE
feat: add Magic.Filler

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -66,7 +66,7 @@ Style Notes
 
 * Created `KLayout.Filler`
 
-  * Add generic implementation.
+  * Added generic implementation.
   * Added ihp-sg13g2/ihp-sg13cmos5l implementation.
 
 * Created `KLayout.Density`
@@ -110,6 +110,10 @@ Style Notes
   * Added `MAGIC_DRC_MAGLEFS`
 
     * Used to blackbox cells during DRC
+
+* Created `Magic.Filler`
+
+  * Added generic implementation.
 
 * `Magic.StreamOut`
 

--- a/librelane/scripts/klayout/insert_cell.py
+++ b/librelane/scripts/klayout/insert_cell.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright 2025 LibreLane Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pya
+
+
+def insert_cell(
+    input: str,
+    insert: str,
+    output: str,
+):
+    # The main layout where the cell is inserted
+    main_layout = pya.Layout()
+    main_layout.read(input)
+    top = main_layout.top_cell()
+
+    # The cell to insert
+    insert_layout = pya.Layout()
+    insert_layout.read(insert)
+
+    def copy_cell_to_layout(target_layout, cell):
+        cell_in_target = target_layout.create_cell(cell.name)
+        cell_in_target.copy_tree(cell)
+        return cell_in_target
+
+    # Copy the complete cell tree
+    insert_in_main = copy_cell_to_layout(main_layout, insert_layout.top_cell())
+
+    # Instantiate the cell
+    top.insert(pya.DCellInstArray(insert_in_main.cell_index(), pya.DTrans(0, 0)))
+
+    main_layout.write(output)
+
+
+if __name__ == "__main__":
+    insert_cell(input, insert, output)  # noqa: F821

--- a/librelane/steps/magic.py
+++ b/librelane/steps/magic.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import subprocess
+from os.path import abspath
 from signal import SIGKILL
 from decimal import Decimal
 from abc import abstractmethod
@@ -380,6 +381,109 @@ class StreamOut(MagicStep):
         )
 
         return views_updates, metrics_updates
+
+
+@Step.factory.register()
+class Filler(Step):
+    """
+    Generates the filler cells according to the design rules and adds them to the GDS.
+    """
+
+    id = "Magic.Filler"
+    name = "Filler Generation"
+
+    inputs = [DesignFormat.GDS]
+    outputs = [DesignFormat.GDS]
+
+    config_vars = [
+        Variable(
+            "MAGIC_FILLER_SCRIPT",
+            Optional[Path],
+            "Path to the magic filler script.",
+            pdk=True,
+        ),
+        Variable(
+            "MAGIC_FILLER_OPTIONS",
+            Optional[List[str]],
+            "Options passed directly to the magic filler script.",
+            pdk=True,
+        ),
+    ]
+
+    def run(self, state_in: State, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
+        metrics_updates: MetricsUpdate = {}
+        views_updates: ViewsUpdate = {}
+
+        if not self.config["MAGIC_FILLER_SCRIPT"]:
+            self.warn(
+                f"MAGIC_FILLER_SCRIPT is unset. Magic.Filler may not be supported for the {self.config['PDK']} PDK. This step will be skipped."
+            )
+            return views_updates, metrics_updates
+
+        views_updates, metrics_updates = self.run_generic(state_in, **kwargs)
+
+        return views_updates, metrics_updates
+
+    def run_generic(
+        self, state_in: State, **kwargs
+    ) -> Tuple[ViewsUpdate, MetricsUpdate]:
+        views_updates: ViewsUpdate = {}
+        kwargs, env = self.extract_env(kwargs)
+
+        input_gds = state_in[DesignFormat.GDS]
+        assert isinstance(input_gds, Path)
+
+        fill_gds = os.path.join(
+            self.step_dir,
+            f"{self.config['DESIGN_NAME']}_fill.{DesignFormat.GDS.extension}",
+        )
+        output_gds = os.path.join(
+            self.step_dir, f"{self.config['DESIGN_NAME']}.{DesignFormat.GDS.extension}"
+        )
+
+        script = abspath(self.config["MAGIC_FILLER_SCRIPT"])
+        opts = self.config["MAGIC_FILLER_OPTIONS"] or []
+
+        env["PDK_ROOT"] = self.config["PDK_ROOT"]
+        env["PDK"] = self.config["PDK"]
+
+        # Run filler generation
+        self.run_subprocess(
+            [
+                "python3",
+                script,
+                input_gds,
+                fill_gds,
+                *opts,
+            ],
+            env=env,
+        )
+
+        # Combine fill and layout
+        self.run_subprocess(
+            [
+                "klayout",
+                "-b",
+                "-zz",
+                "-r",
+                os.path.join(
+                    get_script_dir(),
+                    "klayout",
+                    "insert_cell.py",
+                ),
+                "-rd",
+                f"input={abspath(input_gds)}",
+                "-rd",
+                f"insert={abspath(fill_gds)}",
+                "-rd",
+                f"output={abspath(output_gds)}",
+            ],
+            env=env,
+        )
+
+        views_updates[DesignFormat.GDS] = Path(output_gds)
+
+        return views_updates, {}
 
 
 @Step.factory.register()


### PR DESCRIPTION
Can be used as an alternative to `KLayout.Filler` for PDKs were the KLayout filler script does not exist or is poorly written (I'm looking at you, IHP!).

Example usage:

```yaml
meta:
  version: 3
  flow: Chip
  substituting_steps:
    KLayout.Filler: Magic.Filler
```

Currently, the PDK config does not yet set the variables, as the filler script needs to be updated.
For now, use this script and set them manually:

[generate_fill.py](https://github.com/user-attachments/files/26020979/generate_fill.py)

```yaml
MAGIC_FILLER_SCRIPT: dir::generate_fill.py
MAGIC_FILLER_OPTIONS: ["-keep"] # optional, keep the individual fill sections
```


