### PR TITLE
hotfix: skip StepException on empty SPEF dictionaries

### DIFF
--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -604,7 +604,7 @@ class OpenSTAStep(OpenROADStep):
         name = timing_corner
         current_corner_spef = None
         input_spef_dict = state_in.get(DesignFormat.SPEF)
-        if input_spef_dict is not None:
+        if input_spef_dict is not None and len(input_spef_dict):
             if not isinstance(input_spef_dict, dict):
                 raise StepException(
                     "Malformed input state: value for 'spef' is not a dictionary"


### PR DESCRIPTION
When PDKs don't have RCX calibration files yet, an empty SPEF dictionary would cause a StepException to get raised.