### PR TITLE
feat: specify delay target to ABC

### DIFF
--- a/librelane/scripts/pyosys/construct_abc_script.py
+++ b/librelane/scripts/pyosys/construct_abc_script.py
@@ -57,8 +57,8 @@ class ABCScriptCreator:
 
         self.map_old_area = "map -p -a -B 0.2 -A 0.9 -M 0"
         self.map_old_dly = "map -p -B 0.2 -A 0.9 -M 0"
-        self.retime_area = "retime -M 5"
-        self.retime_dly = "retime -M 6"
+        self.retime_area = f"retime -D {self.D} -M 5"
+        self.retime_dly = f"retime -D {self.D} -M 6"
         self.map_new_area = "amap -m -Q 0.1 -F 20 -A 20 -C 5000"
 
         if config["SYNTH_ABC_AREA_USE_NF"]:
@@ -73,9 +73,9 @@ class ABCScriptCreator:
             max_tr_arg = ""
             if self.max_transition != 0:
                 max_tr_arg = f" -S {self.max_transition}"
-            self.fine_tune = f"buffer -N {self.max_fanout}{max_tr_arg};upsize;dnsize"
+            self.fine_tune = f"buffer -N {self.max_fanout}{max_tr_arg};upsize -D {self.D};dnsize -D {self.D}"
         elif config["SYNTH_SIZING"]:
-            self.fine_tune = "upsize;dnsize"
+            self.fine_tune = f"upsize -D {self.D};dnsize -D {self.D}"
 
     def generate_abc_script(self, step_dir, strategy):
         strategy_clean = re.sub(r"\s+", "_", strategy)
@@ -160,7 +160,7 @@ class ABCScriptCreator:
             else:
                 print(self.delay_mfs3, file=f)
 
-            print("retime", file=f)
+            print(f"retime -D {self.D}", file=f)
 
             # & space
             print("&get -n", file=f)

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -269,8 +269,6 @@ def synthesize(
 
     d.add_blackbox_models(blackbox_models, includes=includes, defines=defines)
 
-    clock_period = config["CLOCK_PERIOD"] * 1000  # ns -> ps
-
     # ABC only supports these two:
     # https://github.com/YosysHQ/abc/blob/28d955ca97a1c4be3aed4062aec0241a734fac5d/src/map/scl/sclUtil.c#L257
     sdc_path = os.path.join(step_dir, "synthesis.abc.sdc")
@@ -458,8 +456,6 @@ def synthesize(
             "abc",
             "-script",
             abc_script,
-            "-D",
-            f"{clock_period}",
             "-constr",
             sdc_path,
             "-showtmp",


### PR DESCRIPTION
Hi there.

I stumbled over the fact that ABC is not told what the delay target is. In #821 the `{D}` placeholder has been removed. I can confirm that it was never used by Yosys i.e. silently dropped if a custom `-script` was used.

I think that telling ABC what the delay target is would nonetheless be important.

The recommended local test of `python3 -m librelane ./examples/spm/config.yaml` worked.

Cheers, Nik