### PR TITLE
feat: add custom ABC strategy script option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -408,6 +408,9 @@ Style Notes
 
     * Removed `LIGHTER_DFF_MAP`: tangentially related to above
 
+  * Added `SYNTH_ABC_STRATEGY_SCRIPT`: custom ABC strategy script that runs
+    instead of the default script of the selected `SYNTH_STRATEGY`.
+
 * `Yosys.Synthesis`
 
   * Graphviz DOT file generation, which frequently fails and brings down the

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -449,11 +449,16 @@ def synthesize(
     script_creator = ABCScriptCreator(config)
 
     def run_strategy(d):
-        abc_script = script_creator.generate_abc_script(
-            step_dir,
-            config["SYNTH_STRATEGY"],
-        )
-        ys.log(f"[INFO] Using generated ABC script '{abc_script}'…")
+        abc_script = config["SYNTH_ABC_STRATEGY_SCRIPT"]
+        if abc_script:
+            ys.log(f"[INFO] Using custom ABC strategy script '{abc_script}'…")
+        else:
+            abc_script = script_creator.generate_abc_script(
+                step_dir,
+                config["SYNTH_STRATEGY"],
+            )
+            ys.log(f"[INFO] Using generated ABC strategy script '{abc_script}'…")
+
         d.run_pass(
             "abc",
             "-script",

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -472,6 +472,11 @@ class SynthesisCommon(VerilogStep):
             default=False,
         ),
         Variable(
+            "SYNTH_ABC_STRATEGY_SCRIPT",
+            Optional[Path],
+            "Custom ABC strategy script. Runs instead of the default script for the selected 'SYNTH_STRATEGY'. All other 'SYNTH_ABC_*' variables except 'SYNTH_ABC_DFF' will have no effect.",
+        ),
+        Variable(
             "SYNTH_DIRECT_WIRE_BUFFERING",
             bool,
             "Enables inserting buffer cells for directly connected wires.",


### PR DESCRIPTION
Hi again.

This adds the option for custom ABC strategy scripts. It bypasses `ABCScriptCreator` and therefore ignores all `SYNTH_ABC_*` configs options except `SYNTH_ABC_DFF`.

This seems to work locally and I can write/use my own custom scripts ... but how can I add a test for this? If I even shall add one? Is there a good example of a test for config options? I had trouble making sense of the test framework ...

Note: I deliberately named this `SYNTH_ABC_STRATEGY_SCRIPT` as I also plan to add a different custom script that can replace the yosys default script when ABC is run in [`scripts/pyosys/synthesize.py`](https://github.com/librelane/librelane/blob/833510f25cdd4a37a06a9af6567978988da29bf3/librelane/scripts/pyosys/synthesize.py#L229):
```python
d.run_pass(
    "abc", "-fast", *(["-dff"] if abc_dff else [])
)
```

Reason for two different places for ABC custom scripts:
 - At the point when the strategy script runs, at least for my usecase, all FFs are already mapped to the target PDK cells. And ABC seems unable to do sequential optimization with them.
 - At the earlier ABC call in `synthesize.py` the FFs are still in the internal Yosys format which ABC handles well.

Cheers, Nik