### PR TITLE
fix: magic DRC markers units

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,14 @@ Style Notes
 
 -->
 
+# 3.0.1
+
+## Steps
+
+* `Magic.DRC`
+
+  * Set units to internal to fix DRC markers for newer magic versions.
+
 # 3.0.0
 
 ## Steps

--- a/librelane/scripts/magic/drc.tcl
+++ b/librelane/scripts/magic/drc.tcl
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 crashbackups disable
+units internal
 
 # Read in maglef views in order to blackbox cells
 if { [info exists ::env(MAGIC_DRC_MAGLEFS)] } {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.0"
+version = "3.0.1"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
I just noticed that, when loading the *.lyrdb generated from the magic markers, the marker coordinates were divided by a certain factor and would end up in the wrong places. This is due to recent changes  magic's handling of units. To maintain the previous behavior, set the units to internal.

* `Magic.DRC`

  * Set units to internal to fix DRC markers for newer magic versions.