### PR TITLE
fix: collisions for old PDK configs with STD_CELL_LIBRARY_OPT

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,28 @@ Style Notes
 
 -->
 
+# 3.0.3
+
+## Steps
+
+* `OpenROAD.STA*`
+
+  * Steps now support versions 3.0 and higher of OpenSTA, which require a
+    slightly different invocation for `write_timing_model`.
+
+* `Verilator.Lint`
+
+  * Upgraded warnings on multiply-driven nets to an error that can be disabled
+    by setting `LINTER_ERROR_ON_MULTIDRIVEN` to `false`.
+
+## Misc. Enhancements/Bugfixes
+
+* `openlane.config`
+
+  * Applied hack/band-aid for an issue where the default standard cell library's
+    variables may clobber those of the current standard cell library because of
+    `STD_CELL_LIBRARY_OPT`, a legacy OpenLane variable.
+
 # 3.0.2
 
 ## Tool Updates

--- a/librelane/config/config.py
+++ b/librelane/config/config.py
@@ -833,6 +833,11 @@ class Config(GenericImmutableDict[str, Any]):
         if scl is not None:
             pdk_config[SpecialKeys.scl] = scl
 
+            # HACK: Prevent loading default SCL cfg vars for old openlane PDK
+            # configs
+            # For more info: https://github.com/librelane/librelane/issues/932
+            pdk_config["STD_CELL_LIBRARY_OPT"] = scl
+
         if pad is not None:
             pdk_config[SpecialKeys.pad] = pad
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.2"
+version = "3.0.3"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
- band-aids an issue where the default standard cell library's variables may clobber those of the current standard cell library because of STD_CELL_LIBRARY_OPT, a legacy OpenLane variable

Resolves #932 