### PR TITLE
ci: add sky130 full-chip design

### DIFF
--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -54,6 +54,9 @@
       script: harden.py
     - name: hold_violations_3
       script: harden.py
+    # Full chip design
+    - name: full_chip_sky130
+      config_file: config.yaml
 - scl: sky130A/sky130_fd_sc_hdll
   name: fastest_test_set
   designs:

--- a/Changelog.md
+++ b/Changelog.md
@@ -44,7 +44,9 @@ Style Notes
 
 ## Misc. Enhancements/Bugfixes
 
-- Split `LIB` into `CELL_LIBS` and `PAD_LIBS`.
+* Split `LIB` into `CELL_LIBS` and `PAD_LIBS`.
+
+* CI: add sky130 full-chip design.
 
 # 3.0.3
 
@@ -570,7 +572,7 @@ Style Notes
 
 ## Misc. Enhancements/Bugfixes
 
-- Added `--pad` and `PAD_CELL_LIBRARY` variable to load the pad configuration
+* Added `--pad` and `PAD_CELL_LIBRARY` variable to load the pad configuration
 
 * `CLI`
 


### PR DESCRIPTION
This adds a full-chip design to the CI.

I added a placement blockage in the center of the chip to speed up the flow:

<img width="450" alt="grafik" src="https://github.com/user-attachments/assets/c5b042df-560b-42fc-bbfb-4719cd8e0bfd" />
