### PR TITLE
fix: include EXTRA_LIBS and macro lib views in synthesis lib set

### DIFF
--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -335,10 +335,13 @@ class VerilogStep(PyosysStep):
                 DesignFormat.LIB,
             ]
         )
-        for view, _ in self.toolbox.get_macro_views_by_priority(
+        macro_lib_views = []
+        for view, fmt in self.toolbox.get_macro_views_by_priority(
             self.config, format_list
         ):
             blackbox_models.append(str(view))
+            if fmt == DesignFormat.LIB:
+                macro_lib_views.append(str(view))
 
         if libs := self.config.get("EXTRA_LIBS"):
             blackbox_models.extend(str(f) for f in libs)
@@ -355,6 +358,10 @@ class VerilogStep(PyosysStep):
             frozenset([str(lib) for lib in scl_lib_list]),
             excluded_cells=frozenset(excluded_cells),
         )
+        if extra_libs := self.config.get("EXTRA_LIBS"):
+            libs_synth.extend(str(f) for f in extra_libs)
+        libs_synth.extend(macro_lib_views)
+        libs_synth = list(dict.fromkeys(libs_synth))
         extra_path = os.path.join(self.step_dir, "extra.json")
         with open(extra_path, "w") as f:
             json.dump({"blackbox_models": blackbox_models, "libs_synth": libs_synth}, f)


### PR DESCRIPTION
By adding this, yosys can then also report the area for cells added in `EXTRA_LIBS`. Before I got the warning
`Area for cell type \cell_added_to_extra_libs is unknown!` This was previously fixed in OpenLane (The-OpenROAD-Project/OpenLane#1646), but I think it got lost in the rewrite.