### PR TITLE
nix: Fixup OpenSTA to properly handle power pins in verilog write

### DIFF
--- a/nix/opensta.nix
+++ b/nix/opensta.nix
@@ -39,6 +39,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./patches/opensta/fix_cell_delays.patch
+    ./patches/opensta/fix_power_pins.patch
   ];
 
   postPatch = ''

--- a/nix/patches/opensta/fix_power_pins.patch
+++ b/nix/patches/opensta/fix_power_pins.patch
@@ -1,0 +1,42 @@
+diff --git a/verilog/VerilogWriter.cc b/verilog/VerilogWriter.cc
+index dd856d7b..681363bc 100644
+--- a/verilog/VerilogWriter.cc
++++ b/verilog/VerilogWriter.cc
+@@ -440,6 +440,7 @@ VerilogWriter::writeInstBusPinBit(const Instance *inst,
+ void
+ VerilogWriter::writeAssigns(const Instance *inst)
+ {
++  // Handle signals
+   InstancePinIterator *pin_iter = network_->pinIterator(inst);
+   while (pin_iter->hasNext()) {
+     Pin *pin = pin_iter->next();
+@@ -463,6 +464,29 @@ VerilogWriter::writeAssigns(const Instance *inst)
+     }
+   }
+   delete pin_iter;
++
++  // Handle power pins
++  if (include_pwr_gnd_) {
++    Cell *cell = network_->cell(inst);
++    CellPortIterator *port_iter = network_->portIterator(cell);
++    while (port_iter->hasNext()) {
++      Port *port = port_iter->next();
++      if (!network_->direction(port)->isPowerGround())
++        continue;
++      Pin *pin = network_->findPin(inst, port);
++      Term *term = pin ? network_->term(pin) : nullptr;
++      Net *net = term ? network_->net(term) : nullptr;
++      if (net && !stringEqual(network_->name(port), network_->name(net))) {
++        // Port name is different from net name.
++        string port_vname = netVerilogName(network_->name(port));
++        string net_vname = netVerilogName(network_->name(net));
++        fprintf(stream_, " assign %s = %s;\n",
++                port_vname.c_str(),
++                net_vname.c_str());
++      }
++    }
++    delete port_iter;
++  }
+ }
+ 
+ ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There has been a change in OpenROAD and the Piniterator no longer lists the power pins ... which is a problem because this is what is used in the VerilogWriter from OpenSTA to write the powered netlist.

The ports still get written, but if the port name and net name don't match, it used to write an assign statement to connect the two for LVS.

The code in OpenSTA to handle this is still there. But because OpenROAD's iterator now doesn't list those in the PirIterator, that code is never called, the assigns are never written and LVS is not happy.

This is especially useful in OpenFrame template from ChipFoundry since we have power ports that map to pins and must have those specific names for integration but we want to internally connect them to the same power rails.