### PR TITLE
fix: remove all the formal cells during synthesis

### DIFF
--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -157,6 +157,7 @@ def librelane_synth(
 ):
 
     d.run_pass("hierarchy", "-check", "-top", top, "-nokeep_prints", "-nokeep_asserts")
+    d.run_pass("chformal", "-remove")
     librelane_proc(d, report_dir)
 
     if keep_hierarchy_min_cost:


### PR DESCRIPTION
This PR removes the formal cells (`$check`, ...) during the synthesis pass as explained in #949.

This is done by running `chformal -remove` at the beginning of the synthesis script.