### PR TITLE
cleanup: removed unused variables SYNTH_MUX_MAP/SYNTH_MUX4_MAP

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,12 @@ Style Notes
   * Upgraded warnings on multiply-driven nets to an error that can be disabled
     by setting `LINTER_ERROR_ON_MULTIDRIVEN` to `false`.
 
+* `Yosys.*Synthesis`
+
+  * Removed unused variables `SYNTH_MUX_MAP`/`SYNTH_MUX4_MAP`.
+    As a note, Yosys and ABC are able to map multiplexers to SCL cells
+    without explicit technology mapping.
+
 ## Misc. Enhancements/Bugfixes
 
 * `openlane.config`

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -195,18 +195,6 @@ class PyosysStep(Step):
             pdk=True,
         ),
         Variable(
-            "SYNTH_MUX_MAP",
-            Optional[Path],
-            "A path to a file containing the mux mapping for Yosys.",
-            pdk=True,
-        ),
-        Variable(
-            "SYNTH_MUX4_MAP",
-            Optional[Path],
-            "A path to a file containing the mux4 mapping for Yosys.",
-            pdk=True,
-        ),
-        Variable(
             "SYNTH_CLOCKGATE_MIN_WIDTH",
             Optional[int],
             "If set to a value, a group of flip-flops with size >= SYNTH_CLOCKGATE_MIN_WIDTH and an enable signal are clock-gated instead.",

--- a/librelane/steps/yosys.py
+++ b/librelane/steps/yosys.py
@@ -197,18 +197,6 @@ class YosysStep(TclStep):
             pdk=True,
         ),
         Variable(
-            "SYNTH_MUX_MAP",
-            Optional[Path],
-            "A path to a file containing the mux mapping for Yosys.",
-            pdk=True,
-        ),
-        Variable(
-            "SYNTH_MUX4_MAP",
-            Optional[Path],
-            "A path to a file containing the mux4 mapping for Yosys.",
-            pdk=True,
-        ),
-        Variable(
             "YOSYS_LOG_LEVEL",
             Literal["ALL", "WARNING", "ERROR"],
             "Which log level for Yosys. At WARNING or higher, the initialization splash is also disabled.",


### PR DESCRIPTION
After investigating Yosys technology mapping files inside `open_pdks` `sky130` I noticed the `SYNTH_MUX_MAP`/`SYNTH_MUX4_MAP` variables and therefore the mapping files are not used. Nevertheless Yosys and ABC do a good job mapping multiplexers to standard cells.

The question remain whether to also remove related code and files from `open_pdks`.

I have removed the variables and updated the changelog.