### PR TITLE
feat: magic: disable locking, crashbackups and drc where appropriate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,14 @@ Style Notes
 
 -->
 
+# 3.0.4
+
+## Steps
+
+* `Magic.*`
+
+  * Added `locking disable` to scripts to prevent exceeding max open file descriptor limit.
+
 # 3.0.3
 
 ## Steps

--- a/librelane/scripts/magic/def/antenna_check.tcl
+++ b/librelane/scripts/magic/def/antenna_check.tcl
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/magic/def/read.tcl
+drc off
+crashbackups disable
+locking disable
 
 load $::env(DESIGN_NAME) -dereference
 

--- a/librelane/scripts/magic/def/mag.tcl
+++ b/librelane/scripts/magic/def/mag.tcl
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 source $::env(SCRIPTS_DIR)/magic/def/read.tcl
+drc off
+crashbackups disable
+locking disable
 
 save $::env(SAVE_MAG)
 

--- a/librelane/scripts/magic/def/mag_gds.tcl
+++ b/librelane/scripts/magic/def/mag_gds.tcl
@@ -18,6 +18,7 @@
 source $::env(SCRIPTS_DIR)/magic/common/read.tcl
 drc off
 crashbackups disable
+locking disable
 
 gds noduplicates true
 gds readonly true

--- a/librelane/scripts/magic/drc.tcl
+++ b/librelane/scripts/magic/drc.tcl
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 crashbackups disable
+locking disable
 units internal
 
 # Read in maglef views in order to blackbox cells

--- a/librelane/scripts/magic/extract_spice.tcl
+++ b/librelane/scripts/magic/extract_spice.tcl
@@ -20,6 +20,9 @@ puts $f [expr {((round([magic::cif scale output] * 10000)) / 10000.0) * 1}]
 close $f
 
 source $::env(SCRIPTS_DIR)/magic/common/read.tcl
+drc off
+crashbackups disable
+locking disable
 
 if { $::env(MAGIC_EXT_USE_GDS) } {
     gds read $::env(CURRENT_GDS)

--- a/librelane/scripts/magic/gds/drc_batch.tcl
+++ b/librelane/scripts/magic/gds/drc_batch.tcl
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+crashbackups disable
+locking disable
+
 if { [info exists ::env(TECH)] } {
     tech load $::env(TECH)
 }

--- a/librelane/scripts/magic/gds/erase_box.tcl
+++ b/librelane/scripts/magic/gds/erase_box.tcl
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+drc off
+crashbackups disable
+locking disable
+
 tech unlock *
 
 gds read $::env(CURRENT_GDS)

--- a/librelane/scripts/magic/gds/extras_mag.tcl
+++ b/librelane/scripts/magic/gds/extras_mag.tcl
@@ -17,6 +17,8 @@
 # corresponding maglefs
 
 drc off
+crashbackups disable
+locking disable
 
 gds readonly true
 gds rescale false

--- a/librelane/scripts/magic/gds/mag_with_pointers.tcl
+++ b/librelane/scripts/magic/gds/mag_with_pointers.tcl
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 drc off
+crashbackups disable
+locking disable
 
 gds readonly true
 gds rescale false

--- a/librelane/scripts/magic/get_bbox.tcl
+++ b/librelane/scripts/magic/get_bbox.tcl
@@ -1,3 +1,7 @@
+drc off
+crashbackups disable
+locking disable
+
 gds read $::env(_GDS_IN)
 load $::env(_MACRO_NAME_IN)
 set curunits [units]

--- a/librelane/scripts/magic/lef.tcl
+++ b/librelane/scripts/magic/lef.tcl
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 drc off
+crashbackups disable
+locking disable
+
 if { $::env(MAGIC_LEF_WRITE_USE_GDS) } {
     gds read $::env(CURRENT_GDS)
 } else {

--- a/librelane/scripts/magic/lef/extras_maglef.tcl
+++ b/librelane/scripts/magic/lef/extras_maglef.tcl
@@ -15,6 +15,8 @@
 # convert all external macros to maglef views with GDS_* pointers
 
 drc off
+crashbackups disable
+locking disable
 
 if {  [info exist ::env(EXTRA_LEFS)] } {
 	foreach lef_file $::env(EXTRA_LEFS) {

--- a/librelane/scripts/magic/lef/maglef.tcl
+++ b/librelane/scripts/magic/lef/maglef.tcl
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 drc off
+crashbackups disable
+locking disable
 
 lef read $::env(signoff_results)/$::env(DESIGN_NAME).lef
 

--- a/librelane/scripts/magic/spice_rcx.tcl
+++ b/librelane/scripts/magic/spice_rcx.tcl
@@ -16,6 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+drc off
+crashbackups disable
+locking disable
+
 # we do always want to read the GDS for this
 gds read $::env(CURRENT_GDS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.3"
+version = "3.0.4"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
Depending on the script we can disable crashbackups and locking, as well as drc when not needed.

Fixes #818