### PR TITLE
feat: use SYNTH_BUFFER_CELL for port buffering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -56,6 +56,10 @@ Style Notes
 
   * Added `PDN_CORE_RING_CONNECT_TO_PAD_LAYERS` to restrict the layers for connecting to pads.
 
+* OpenROAD.RepairDesign
+
+  * Use `SYNTH_BUFFER_CELL` for port buffering.
+
 ## Tool Updates
 
 * Updated nix-eda to 6.24.0
@@ -69,6 +73,7 @@ Style Notes
   * Updated Verilator to `5.046`
   * Updated Iverilog to `13.0`
   * Updated KLayout to `0.30.9`
+* Updated Ciel to 2.5.0
 
 ## Misc. Enhancements/Bugfixes
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776888766,
-        "narHash": "sha256-j3U04anOniDE+nHo2mnbGeXCt8izCFrD06qxQDEw2rQ=",
+        "lastModified": 1780932696,
+        "narHash": "sha256-EDXsR2cBU8+Z4h/Pkac5An9/TVI9LkZqLB3xAjrQq78=",
         "owner": "fossi-foundation",
         "repo": "ciel",
-        "rev": "88e4875d801b0d59b3e96f504123628acf830c2a",
+        "rev": "64348a98fa8d07a20ad1f3c1183cf30d7d310055",
         "type": "github"
       },
       "original": {
         "owner": "fossi-foundation",
+        "ref": "2.5.0",
         "repo": "ciel",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   inputs = {
     nix-eda.url = "github:fossi-foundation/nix-eda/6.24.0";
-    ciel.url = "github:fossi-foundation/ciel";
+    ciel.url = "github:fossi-foundation/ciel/2.5.0";
     devshell.url = "github:numtide/devshell";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };

--- a/librelane/scripts/openroad/repair_design.tcl
+++ b/librelane/scripts/openroad/repair_design.tcl
@@ -33,12 +33,15 @@ if { $::env(DESIGN_REPAIR_REMOVE_BUFFERS) } {
     remove_buffers
 }
 
+# Use SYNTH_BUFFER_CELL as buffer, since OpenROAD may select a hold/delay buffer
+# See: https://github.com/librelane/librelane/pull/961
+
 if { $::env(DESIGN_REPAIR_BUFFER_INPUT_PORTS) } {
-    buffer_ports -inputs
+    buffer_ports -inputs -buffer_cell [lindex [split $::env(SYNTH_BUFFER_CELL) "/"] 0]
 }
 
 if { $::env(DESIGN_REPAIR_BUFFER_OUTPUT_PORTS) } {
-    buffer_ports -outputs
+    buffer_ports -outputs -buffer_cell [lindex [split $::env(SYNTH_BUFFER_CELL) "/"] 0]
 }
 
 set arg_list [list]


### PR DESCRIPTION
This is required since OpenROAD would otherwise choose a random buffer. In the case of gf180mcu, it would even choose a delay buffer.

Additionally, update Ciel to the latest version.

## Steps

* OpenROAD.RepairDesign

  * Use `SYNTH_BUFFER_CELL` for port buffering.

## Tool Updates

* Updated Ciel to 2.5.0