### PR TITLE
feat: support for multiples LINTER_VLT files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,7 +29,7 @@ Style Notes
 
 ## Steps
 
-* KLayout.DRC
+* `KLayout.DRC`
 
   * `KLAYOUT_DRC_OPTIONS`: changed order of type evaluation so that `threads: 1` is evaluated as integer.
 
@@ -65,7 +65,7 @@ Style Notes
 
   * Added `PDN_CORE_RING_CONNECT_TO_PAD_LAYERS` to restrict the layers for connecting to pads.
 
-* OpenROAD.RepairDesign
+* `OpenROAD.RepairDesign`
 
   * Use `SYNTH_BUFFER_CELL` for port buffering.
 
@@ -75,6 +75,10 @@ Style Notes
     CPU cores on your machine
 
   * Deprecated `DRT_THREADS`, use the above (`OPENROAD_THREADS`) instead
+
+* `Verilator.Lint`
+
+  * `LINTER_VLT` is now a list of paths instead of a single path.
 
 ## Tool Updates
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -78,7 +78,9 @@ Style Notes
 
 * `Verilator.Lint`
 
-  * `LINTER_VLT` is now a list of paths instead of a single path.
+  * Added `LINTER_VLTS` to specify a list of paths to Verilator Control Files.
+
+  * Deprecated `LINTER_VLT`. Replaced by `LINTER_VLTS`.
 
 ## Tool Updates
 

--- a/librelane/steps/verilator.py
+++ b/librelane/steps/verilator.py
@@ -108,8 +108,8 @@ class Lint(Step):
         ),
         Variable(
             "LINTER_VLT",
-            Optional[Path],
-            "Path to a Verilator Configuration format file (`.vlt`) that is passed to the linter.",
+            Optional[List[Path]],
+            "List of paths to Verilator Configuration format files (`.vlt`) that are passed to the linter.",
         ),
     ]
 
@@ -218,7 +218,7 @@ class Lint(Step):
             extra_args.append(f"+define+{define}")
 
         if linter_vlt := self.config["LINTER_VLT"]:
-            extra_args.append(linter_vlt)
+            extra_args.extend(linter_vlt)
 
         result = self.run_subprocess(
             [

--- a/librelane/steps/verilator.py
+++ b/librelane/steps/verilator.py
@@ -107,9 +107,10 @@ class Lint(Step):
             default=["UNDRIVEN", "UNUSEDSIGNAL"],
         ),
         Variable(
-            "LINTER_VLT",
+            "LINTER_VLTS",
             Optional[List[Path]],
             "List of paths to Verilator Configuration format files (`.vlt`) that are passed to the linter.",
+            deprecated_names=[("LINTER_VLT", lambda x: [x])],
         ),
     ]
 
@@ -217,8 +218,8 @@ class Lint(Step):
         for define in defines:
             extra_args.append(f"+define+{define}")
 
-        if linter_vlt := self.config["LINTER_VLT"]:
-            extra_args.extend(linter_vlt)
+        if linter_vlts := self.config["LINTER_VLTS"]:
+            extra_args.extend(linter_vlts)
 
         result = self.run_subprocess(
             [


### PR DESCRIPTION
This allows to specify a list of paths to `.vlt` files for the `LINTER_VLT` variable.