### PR TITLE
OpenROAD.*: Introduce PDN_PAD_CONNECTIONS

### DIFF
--- a/librelane/scripts/openroad/common/set_global_connections.tcl
+++ b/librelane/scripts/openroad/common/set_global_connections.tcl
@@ -13,49 +13,65 @@
 # limitations under the License.
 
 # Power nets
+
+# Applies a list of PDN connection hooks as global power/ground connections.
+# Each hook has the format "<instance_name_rx> <vdd_net> <gnd_net> <vdd_pin>
+# <gnd_pin>" and is shared by PDN_MACRO_CONNECTIONS and PDN_PAD_CONNECTIONS.
+# `label` is used only for diagnostics.
+proc _apply_pdn_connections {connections label} {
+    foreach pdn_hook $connections {
+        set pdn_hook [regexp -all -inline {\S+} $pdn_hook]
+        set instance_name [lindex $pdn_hook 0]
+        set power_net [lindex $pdn_hook 1]
+        set ground_net [lindex $pdn_hook 2]
+        set power_pin [lindex $pdn_hook 3]
+        set ground_pin [lindex $pdn_hook 4]
+
+        if { $power_pin == "" || $ground_pin == "" } {
+            puts "$label missing power and ground pin names"
+            exit_unless_gui 1
+        }
+
+        set matched 0
+        foreach cell [[ord::get_db_block] getInsts] {
+            if { [regexp "\^$instance_name\$" [$cell getName]] } {
+                set matched 1
+                puts "$instance_name matched with [$cell getName]"
+            }
+        }
+        if { $matched != 1 } {
+            puts stderr "\[ERROR\] No match found for regular expression '$instance_name' defined in $label."
+            exit_unless_gui 1
+        }
+
+        add_global_connection \
+            -net $power_net \
+            -inst_pattern $instance_name \
+            -pin_pattern $power_pin \
+            -power
+
+        add_global_connection \
+            -net $ground_net \
+            -inst_pattern $instance_name \
+            -pin_pattern $ground_pin \
+            -ground
+    }
+}
+
 proc set_global_connections {} {
     puts "\[INFO\] Setting global connections..."
 
     # Make global connections for macros
     if { $::env(PDN_CONNECT_MACROS_TO_GRID) == 1 &&
         [info exists ::env(PDN_MACRO_CONNECTIONS)]} {
-        foreach pdn_hook $::env(PDN_MACRO_CONNECTIONS) {
-            set pdn_hook [regexp -all -inline {\S+} $pdn_hook]
-            set instance_name [lindex $pdn_hook 0]
-            set power_net [lindex $pdn_hook 1]
-            set ground_net [lindex $pdn_hook 2]
-            set power_pin [lindex $pdn_hook 3]
-            set ground_pin [lindex $pdn_hook 4]
+        _apply_pdn_connections $::env(PDN_MACRO_CONNECTIONS) "PDN_MACRO_CONNECTIONS"
+    }
 
-            if { $power_pin == "" || $ground_pin == "" } {
-                puts "PDN_MACRO_CONNECTIONS missing power and ground pin names"
-                exit_unless_gui 1
-            }
-
-            set matched 0
-            foreach cell [[ord::get_db_block] getInsts] {
-                if { [regexp "\^$instance_name\$" [$cell getName]] } {
-                    set matched 1
-                    puts "$instance_name matched with [$cell getName]"
-                }
-            }
-            if { $matched != 1 } {
-                puts stderr "\[ERROR\] No match found for regular expression '$instance_name' defined in PDN_MACRO_CONNECTIONS."
-                exit_unless_gui 1
-            }
-
-            add_global_connection \
-                -net $power_net \
-                -inst_pattern $instance_name \
-                -pin_pattern $power_pin \
-                -power
-
-            add_global_connection \
-                -net $ground_net \
-                -inst_pattern $instance_name \
-                -pin_pattern $ground_pin \
-                -ground
-        }
+    # Make global connections for the padframe (PDK level, chip flow only)
+    if { [info exists ::env(PDN_CONNECT_PADS_TO_GRID)] &&
+        $::env(PDN_CONNECT_PADS_TO_GRID) == 1 &&
+        [info exists ::env(PDN_PAD_CONNECTIONS)]} {
+        _apply_pdn_connections $::env(PDN_PAD_CONNECTIONS) "PDN_PAD_CONNECTIONS"
     }
 
     # Make global connections for SCLs

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -269,6 +269,18 @@ class OpenROADStep(TclStep):
             deprecated_names=[("FP_PDN_MACRO_HOOKS", pdn_macro_migrator)],
         ),
         Variable(
+            "PDN_CONNECT_PADS_TO_GRID",
+            bool,
+            "Enables the connection of padframe cells (PDN_PAD_CONNECTIONS) to the power grid. Should only be enabled for top-level (chip) flows that contain a padframe.",
+            default=False,
+        ),
+        Variable(
+            "PDN_PAD_CONNECTIONS",
+            Optional[List[str]],
+            "Specifies explicit power connections of padframe cells to the power grid, in the same format as PDN_MACRO_CONNECTIONS: `<instance_name_rx> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>`. Intended to be set at the PDK level so the padframe supply nets are always connected; only applied when PDN_CONNECT_PADS_TO_GRID is enabled.",
+            pdk=True,
+        ),
+        Variable(
             "PDN_ENABLE_GLOBAL_CONNECTIONS",
             bool,
             "Enables the creation of global connections in PDN generation.",


### PR DESCRIPTION
Newer versions of OpenROAD will automatically assign unconnected nets in the padframe. This will add fake nets like
  IO_CORNER_NORTH_WEST_INST.vdd_RING
to the padframe. Unfortunately, the padframe can't be connected to the core VDD/VSS nets since the net names don't match.

Rework the set_global_connections function and introduce a new variable called PDN_PAD_CONNECTIONS. It's doing the same as PDN_MACRO_CONNECTIONS, but can be set on the PDK level to prevent any misconfiguration due missing padframe nets in
PDN_MACRO_CONNECTIONS.