### PR TITLE
OpenROAD.RCX: Use set_extraction_rules_file

### DIFF
--- a/librelane/scripts/openroad/rcx.tcl
+++ b/librelane/scripts/openroad/rcx.tcl
@@ -26,7 +26,6 @@ if { !$::env(RCX_MERGE_VIA_WIRE_RES) } {
 # RCX
 puts "Using RCX ruleset '$::env(RCX_RULESET)'…"
 define_process_corner -ext_model_index 0 CURRENT_CORNER
-log_cmd extract_parasitics $rcx_flags\
-    -ext_model_file $::env(RCX_RULESET)\
-    -lef_res
+set_extraction_rules_file $::env(RCX_RULESET)
+log_cmd extract_parasitics $rcx_flags -lef_res
 write_views


### PR DESCRIPTION
Use "set_extraction_rules_file" because "-ext_model_file" is now deprecated.

  [OpenROAD.RCX] [RCX-0514] The -ext_model_file option is deprecated.
  Use set_extraction_rules_file command instead.