### PR TITLE
feat: allow to connect only some of the power/ground ports of an instance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -53,6 +53,8 @@ Style Notes
 
   * Consider busses in power/ground ports. Before, i.e., `VCCD_PAD[0]` and `VCCD_PAD[1]` would be shorted to `VCCD_PAD`.
 
+  * Allow to connect only some of the power/ground ports of an instance.
+
 * `OpenROAD.PadRing`
 
   * Added `PAD_ROTATION_[HORIZONTAL|VERTICAL|CORNER]` for pad cells that require it (e.g. sky130).

--- a/librelane/scripts/odbpy/power_utils.py
+++ b/librelane/scripts/odbpy/power_utils.py
@@ -121,19 +121,20 @@ class Design(object):
                 # Bad Verilog view-- error would break backcompat
                 continue
             connection_bits = connections[pin_name]
-            if len(connection_bits) != 1:
+            if len(connection_bits) > 1:
                 print(
                     f"[ERROR] Unexpectedly found more than one bit connected to {sigtype} pin {module_name}/{pin_name}."
                 )
                 exit(-1)
-            connection_bit = connection_bits[0]
-            connected_to_v = self.get_verilog_net_name_by_bit(
-                top_module,
-                connection_bit,
-            )
-            (power_pins if sigtype == "POWER" else ground_pins)[
-                pin_name
-            ] = connected_to_v
+            if len(connection_bits) == 1:
+                connection_bit = connection_bits[0]
+                connected_to_v = self.get_verilog_net_name_by_bit(
+                    top_module,
+                    connection_bit,
+                )
+                (power_pins if sigtype == "POWER" else ground_pins)[
+                    pin_name
+                ] = connected_to_v
 
         return power_pins, ground_pins
 


### PR DESCRIPTION
I noticed this issue when I wanted to connect only the VPWR/VGND ports of a power switch and leave the switched output unconnected for testing.

A simple fix: only throw an error if there are more than one connections, only make the connection if there is a connection.