### PR TITLE
fix: replace `KLAYOUT_*_OPTIONS` with `KLAYOUT_*_DEFINES`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,22 @@ Style Notes
 
 -->
 
+# 3.0.9
+
+## Steps
+
+* `KLayout.DRC`
+
+  * Added `KLAYOUT_DRC_DEFINES`, which replaces `KLAYOUT_DRC_OPTIONS`.
+
+* `KLayout.Filler`
+
+  * Added `KLAYOUT_FILLER_DEFINES`, which replaces `KLAYOUT_FILLER_OPTIONS`.
+
+* `KLayout.Density`
+
+  * Added `KLAYOUT_DENSITY_DEFINES`, which replaces `KLAYOUT_DENSITY_OPTIONS`.
+
 # 3.0.8
 
 ## Steps

--- a/librelane/config/__init__.py
+++ b/librelane/config/__init__.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/librelane/config/__main__.py
+++ b/librelane/config/__main__.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/librelane/config/config.py
+++ b/librelane/config/config.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/librelane/config/flow.py
+++ b/librelane/config/flow.py
@@ -1,6 +1,6 @@
 # Copyright 2025 LibreLane Contributors
 #
-# Adapted from OpenLane
+# Adapted from OpenLane 2
 #
 # Copyright 2023 Efabless Corporation
 #

--- a/librelane/config/pdk_compat.py
+++ b/librelane/config/pdk_compat.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023-2025 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -349,5 +353,21 @@ def migrate_old_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     elif new["PDK"].startswith("gf180mcu"):
         if "HEURISTIC_ANTENNA_THRESHOLD" not in config:
             new["HEURISTIC_ANTENNA_THRESHOLD"] = 130
+
+    # x7. KLAYOUT_DRC_OPTIONS to defines
+    if new["PDK"].startswith("sky130") and "KLAYOUT_DRC_OPTIONS" in new:
+        tcl_dict = new["KLAYOUT_DRC_OPTIONS"]
+        ws_rx = re.compile(r"\s+")
+        del new["KLAYOUT_DRC_OPTIONS"]
+        new["KLAYOUT_DRC_DEFINES"] = {}
+        # deliberately not checking for bad dicts or dicts that require quoting
+        # it's already overkill to assume people modified the PDK files here
+        #
+        # if someone complains we can parse a Tcl dict later
+        tcl_dict_entries = ws_rx.split(tcl_dict)
+        while len(tcl_dict_entries):
+            key = tcl_dict_entries.pop(0)
+            value = tcl_dict_entries.pop(0)
+            new["KLAYOUT_DRC_DEFINES"][key] = value
 
     return new

--- a/librelane/config/preprocessor.py
+++ b/librelane/config/preprocessor.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/librelane/config/removals.py
+++ b/librelane/config/removals.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/librelane/config/variable.py
+++ b/librelane/config/variable.py
@@ -1,3 +1,7 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane 2
+#
 # Copyright 2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/librelane/steps/klayout.py
+++ b/librelane/steps/klayout.py
@@ -1041,7 +1041,10 @@ class Filler(KLayoutStep):
             "Options passed directly to the KLayout filler runset. They vary from one PDK to another.",
             pdk=True,
             deprecated_names=[
-                ("KLAYOUT_FILLER_OPTIONS", lambda x: {k: str(v) for k, v in x.items()})
+                (
+                    "KLAYOUT_FILLER_OPTIONS",
+                    lambda x: {k: str(v) for k, v in (x or {}).items()},
+                )
             ],
         ),
     ]
@@ -1179,7 +1182,10 @@ class Density(KLayoutStep):
             "Options passed directly to the KLayout density runset. They vary from one PDK to another.",
             pdk=True,
             deprecated_names=[
-                ("KLAYOUT_DENSITY_OPTIONS", lambda x: {k: str(v) for k, v in x.items()})
+                (
+                    "KLAYOUT_DENSITY_OPTIONS",
+                    lambda x: {k: str(v) for k, v in (x or {}).items()},
+                )
             ],
         ),
         Variable(
@@ -1295,10 +1301,16 @@ class Antenna(KLayoutStep):
             pdk=True,
         ),
         Variable(
-            "KLAYOUT_ANTENNA_OPTIONS",
-            Optional[Dict[str, Union[bool, int, str]]],
-            "Options passed directly to the KLayout density runset. They vary from one PDK to another.",
+            "KLAYOUT_ANTENNA_DEFINES",
+            Optional[Dict[str, str]],
+            "Options passed directly to the KLayout antenna runset. They vary from one PDK to another.",
             pdk=True,
+            deprecated_names=[
+                (
+                    "KLAYOUT_ANTENNA_OPTIONS",
+                    lambda x: {k: str(v) for k, v in (x or {}).items()},
+                )
+            ],
         ),
     ]
 
@@ -1330,8 +1342,8 @@ class Antenna(KLayoutStep):
         json_report = os.path.join(reports_dir, "antenna.klayout.json")
 
         opts = []
-        if self.config["KLAYOUT_ANTENNA_OPTIONS"]:
-            for k, v in self.config["KLAYOUT_ANTENNA_OPTIONS"].items():
+        if self.config["KLAYOUT_ANTENNA_DEFINES"]:
+            for k, v in self.config["KLAYOUT_ANTENNA_DEFINES"].items():
                 opts.extend(
                     [
                         "-rd",

--- a/librelane/steps/klayout.py
+++ b/librelane/steps/klayout.py
@@ -454,10 +454,13 @@ class DRC(KLayoutStep):
             deprecated_names=["KLAYOUT_DRC_TECH_SCRIPT"],
         ),
         Variable(
-            "KLAYOUT_DRC_OPTIONS",
-            Optional[Dict[str, Union[bool, int, str]]],
+            "KLAYOUT_DRC_DEFINES",
+            Optional[Dict[str, str]],
             "Options passed directly to the KLayout DRC runset. They vary from one PDK to another.",
             pdk=True,
+            deprecated_names=[
+                ("KLAYOUT_DRC_OPTIONS", lambda x: {k: str(v) for k, v in x.items()})
+            ],
         ),
         Variable(
             "KLAYOUT_DRC_THREADS",
@@ -500,8 +503,8 @@ class DRC(KLayoutStep):
         assert isinstance(input_view, Path)
 
         opts = []
-        if self.config["KLAYOUT_DRC_OPTIONS"]:
-            for k, v in self.config["KLAYOUT_DRC_OPTIONS"].items():
+        if self.config["KLAYOUT_DRC_DEFINES"]:
+            for k, v in self.config["KLAYOUT_DRC_DEFINES"].items():
                 opts.extend(
                     [
                         "-rd",
@@ -564,13 +567,13 @@ class DRC(KLayoutStep):
         drc_script_path = self.config["KLAYOUT_DRC_RUNSET"]
         lyrdb_report = os.path.join(reports_dir, "drc.klayout.lyrdb")
         json_report = os.path.join(reports_dir, "drc.klayout.json")
-        feol = str(self.config["KLAYOUT_DRC_OPTIONS"]["feol"]).lower()
-        beol = str(self.config["KLAYOUT_DRC_OPTIONS"]["beol"]).lower()
+        feol = str(self.config["KLAYOUT_DRC_DEFINES"]["feol"]).lower()
+        beol = str(self.config["KLAYOUT_DRC_DEFINES"]["beol"]).lower()
         floating_metal = str(
-            self.config["KLAYOUT_DRC_OPTIONS"]["floating_metal"]
+            self.config["KLAYOUT_DRC_DEFINES"]["floating_metal"]
         ).lower()
-        offgrid = str(self.config["KLAYOUT_DRC_OPTIONS"]["offgrid"]).lower()
-        seal = str(self.config["KLAYOUT_DRC_OPTIONS"]["seal"]).lower()
+        offgrid = str(self.config["KLAYOUT_DRC_DEFINES"]["offgrid"]).lower()
+        seal = str(self.config["KLAYOUT_DRC_DEFINES"]["seal"]).lower()
         threads = self.config["KLAYOUT_DRC_THREADS"] or _get_process_limit()
         info(f"Running KLayout DRC with {threads} threads…")
 
@@ -644,8 +647,8 @@ class DRC(KLayoutStep):
         assert isinstance(input_view, Path)
 
         opts = []
-        if self.config["KLAYOUT_DRC_OPTIONS"]:
-            for k, v in self.config["KLAYOUT_DRC_OPTIONS"].items():
+        if self.config["KLAYOUT_DRC_DEFINES"]:
+            for k, v in self.config["KLAYOUT_DRC_DEFINES"].items():
                 opts.extend(
                     [
                         "-rd",
@@ -713,8 +716,8 @@ class DRC(KLayoutStep):
         assert isinstance(input_view, Path)
 
         opts = []
-        if self.config["KLAYOUT_DRC_OPTIONS"]:
-            for k, v in self.config["KLAYOUT_DRC_OPTIONS"].items():
+        if self.config["KLAYOUT_DRC_DEFINES"]:
+            for k, v in self.config["KLAYOUT_DRC_DEFINES"].items():
                 opts.extend(
                     [
                         "-rd",
@@ -1033,10 +1036,13 @@ class Filler(KLayoutStep):
             pdk=True,
         ),
         Variable(
-            "KLAYOUT_FILLER_OPTIONS",
-            Optional[Dict[str, Union[bool, int, str]]],
-            "Options passed directly to the KLayout filler script. They vary from one PDK to another.",
+            "KLAYOUT_FILLER_DEFINES",
+            Optional[Dict[str, str]],
+            "Options passed directly to the KLayout filler runset. They vary from one PDK to another.",
             pdk=True,
+            deprecated_names=[
+                ("KLAYOUT_FILLER_OPTIONS", lambda x: {k: str(v) for k, v in x.items()})
+            ],
         ),
     ]
 
@@ -1072,8 +1078,8 @@ class Filler(KLayoutStep):
         script = self.config["KLAYOUT_FILLER_SCRIPT"]
 
         opts = []
-        if self.config["KLAYOUT_FILLER_OPTIONS"]:
-            for k, v in self.config["KLAYOUT_FILLER_OPTIONS"].items():
+        if self.config["KLAYOUT_FILLER_DEFINES"]:
+            for k, v in self.config["KLAYOUT_FILLER_DEFINES"].items():
                 opts.extend(
                     [
                         "-rd",
@@ -1115,6 +1121,16 @@ class Filler(KLayoutStep):
 
         script = self.config["KLAYOUT_FILLER_SCRIPT"]
 
+        opts = []
+        if self.config["KLAYOUT_FILLER_DEFINES"]:
+            for k, v in self.config["KLAYOUT_FILLER_DEFINES"].items():
+                opts.extend(
+                    [
+                        "-rd",
+                        f"{k}={v}",
+                    ]
+                )
+
         env["PDK_ROOT"] = self.config["PDK_ROOT"]
         env["PDK"] = self.config["PDK"]
 
@@ -1128,6 +1144,7 @@ class Filler(KLayoutStep):
                 "-rd",
                 f"output_file={abspath(output_gds)}",
                 abspath(input_gds),
+                *opts,
             ],
             env=env,
         )
@@ -1157,10 +1174,13 @@ class Density(KLayoutStep):
             pdk=True,
         ),
         Variable(
-            "KLAYOUT_DENSITY_OPTIONS",
-            Optional[Dict[str, Union[bool, int, str]]],
+            "KLAYOUT_DENSITY_DEFINES",
+            Optional[Dict[str, str]],
             "Options passed directly to the KLayout density runset. They vary from one PDK to another.",
             pdk=True,
+            deprecated_names=[
+                ("KLAYOUT_DENSITY_OPTIONS", lambda x: {k: str(v) for k, v in x.items()})
+            ],
         ),
         Variable(
             "KLAYOUT_DENSITY_THREADS",
@@ -1198,8 +1218,8 @@ class Density(KLayoutStep):
         json_report = os.path.join(reports_dir, "density.klayout.json")
 
         opts = []
-        if self.config["KLAYOUT_DENSITY_OPTIONS"]:
-            for k, v in self.config["KLAYOUT_DENSITY_OPTIONS"].items():
+        if self.config["KLAYOUT_DENSITY_DEFINES"]:
+            for k, v in self.config["KLAYOUT_DENSITY_DEFINES"].items():
                 opts.extend(
                     [
                         "-rd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.8"
+version = "3.0.9"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
Fixes a number of corner cases resulting from ambiguity regarding the types of certain variables by ensuring all variables are defined in the type they are passed to KLayout to, i.e., string defines.