### PR TITLE
pyosys: preserve Liberty file order

### DIFF
--- a/librelane/common/toolbox.py
+++ b/librelane/common/toolbox.py
@@ -363,7 +363,7 @@ class Toolbox(object):
 
     def remove_cells_from_lib(
         self,
-        input_lib_files: FrozenSet[str],
+        input_lib_files: Tuple[str, ...],
         excluded_cells: FrozenSet[str],
     ) -> List[str]:
         """
@@ -372,10 +372,11 @@ class Toolbox(object):
         This function is memoized, i.e., results are cached for a specific set
         of inputs.
 
-        :param input_lib_files: A `frozenset` of input lib files.
+        :param input_lib_files: An ordered tuple of input lib files.
         :param excluded_cells: A `frozenset` of wildcards of cells to remove
             from the files.
-        :returns: A path to the lib file with the removed cells.
+        :returns: Paths to the Liberty files with the cells removed, in the same
+            order as ``input_lib_files``.
         """
         mkdirp(self.tmp_dir)
 

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -340,7 +340,7 @@ class VerilogStep(PyosysStep):
         excluded_cells.update(process_list_file(self.config["PNR_EXCLUDED_CELL_FILE"]))
 
         libs_synth = self.toolbox.remove_cells_from_lib(
-            frozenset([str(lib) for lib in scl_lib_list]),
+            tuple(str(lib) for lib in scl_lib_list),
             excluded_cells=frozenset(excluded_cells),
         )
         extra_path = os.path.join(self.step_dir, "extra.json")

--- a/librelane/steps/yosys.py
+++ b/librelane/steps/yosys.py
@@ -106,7 +106,7 @@ def _generate_read_deps(
     excluded_cells.update(process_list_file(config["PNR_EXCLUDED_CELL_FILE"]))
 
     lib_synth = toolbox.remove_cells_from_lib(
-        frozenset([str(lib) for lib in scl_lib_list]),
+        tuple(str(lib) for lib in scl_lib_list),
         excluded_cells=frozenset(excluded_cells),
     )
     if tcl:

--- a/test/common/test_toolbox.py
+++ b/test/common/test_toolbox.py
@@ -735,14 +735,11 @@ def test_remove_cell_list_from_lib(lib_trim_result):
     excluded_cells = process_list_file("/cwd/bad_cell_list.txt")
 
     result = toolbox.remove_cells_from_lib(
-        frozenset(["/cwd/example_lib.lib", "/cwd/example_lib2.lib"]),
+        ("/cwd/example_lib.lib", "/cwd/example_lib2.lib"),
         excluded_cells=frozenset(excluded_cells),
     )
-    for file in result:
-        contents = open(file, encoding="utf8").read()
-        assert (
-            contents.strip() in lib_trim_result
-        ), "remove_cells_from_lib produced unexpected result"
+    contents = [open(file, encoding="utf8").read().strip() for file in result]
+    assert contents == lib_trim_result, "remove_cells_from_lib changed Liberty order"
 
 
 @pytest.mark.usefixtures("_lib_mock_fs")
@@ -756,14 +753,11 @@ def test_remove_cells_from_lib(lib_trim_result):
     )
 
     result = toolbox.remove_cells_from_lib(
-        frozenset(["/cwd/example_lib.lib", "/cwd/example_lib2.lib"]),
+        ("/cwd/example_lib.lib", "/cwd/example_lib2.lib"),
         excluded_cells=frozenset(excluded_cells),
     )
-    for file in result:
-        contents = open(file, encoding="utf8").read()
-        assert (
-            contents.strip() in lib_trim_result
-        ), "remove_cells_from_lib produced unexpected result"
+    contents = [open(file, encoding="utf8").read().strip() for file in result]
+    assert contents == lib_trim_result, "remove_cells_from_lib changed Liberty order"
 
 
 @mock.patch.dict(os.environ, {"PATH": "/bin"})


### PR DESCRIPTION
Some PDKs split their standard cells across multiple Liberty files. ABC uses the first file as its base library, so the order is important.  This is triggered by the asap7 pdk. (#995)

Librelane should maintain the order of the libraries from the pdk.

