### PR TITLE
Support embedded KLayout LEF/DEF layer maps (LLM-aided)

### DIFF
--- a/librelane/scripts/klayout/open_design.py
+++ b/librelane/scripts/klayout/open_design.py
@@ -16,12 +16,18 @@ import os
 import sys
 import shlex
 import argparse
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pya  # Must be run inside KLayout-- the library version of pya does not include "Application"
 
 
-def open_design(input_lefs: Tuple[str, ...], lyt: str, lyp: str, lym: str, input: str):
+def open_design(
+    input_lefs: Tuple[str, ...],
+    lyt: str,
+    lyp: str,
+    lym: Optional[str],
+    input: str,
+):
     try:
         main_window = pya.Application.instance().main_window()
 
@@ -40,7 +46,8 @@ def open_design(input_lefs: Tuple[str, ...], lyt: str, lyp: str, lym: str, input
         layout_options.lefdef_config.macro_resolution_mode = 1
         layout_options.lefdef_config.read_lef_with_def = False
         layout_options.lefdef_config.lef_files = list(input_lefs)
-        layout_options.lefdef_config.map_file = lym
+        if lym is not None:
+            layout_options.lefdef_config.map_file = lym
 
         cell_view = main_window.load_layout(input, layout_options, tech.name, False)
         layout_view = cell_view.view()
@@ -62,7 +69,7 @@ if __name__ == "__main__":
     parser.add_argument("-T", "--lyt", required=True, help="KLayout .lyt file")
     parser.add_argument("-P", "--lyp", required=True, help="KLayout .lyp file")
     parser.add_argument(
-        "-M", "--lym", required=True, help="KLayout .map (LEF/DEF layer map) file"
+        "-M", "--lym", required=False, help="KLayout .map (LEF/DEF layer map) file"
     )
     parser.add_argument("input", help="KLayout cell name")
 

--- a/librelane/scripts/klayout/render.py
+++ b/librelane/scripts/klayout/render.py
@@ -48,7 +48,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pya
 import click
@@ -77,7 +77,7 @@ import click
 @click.option(
     "-M",
     "--lym",
-    required=True,
+    required=False,
     help="KLayout .map (LEF/DEF layer map) file",
 )
 @click.option(
@@ -122,7 +122,7 @@ def render(
     output: str,
     lyt: str,
     lyp: str,
-    lym: str,
+    lym: Optional[str],
     input: str,
     grid_visible: bool,
     grid_show_ruler: bool,
@@ -141,7 +141,8 @@ def render(
         layout_options = None
         if not gds:
             layout_options = tech.load_layout_options
-            layout_options.lefdef_config.map_file = lym
+            if lym is not None:
+                layout_options.lefdef_config.map_file = lym
             layout_options.lefdef_config.macro_resolution_mode = 1
             layout_options.lefdef_config.read_lef_with_def = False
             layout_options.lefdef_config.lef_files = list(input_lefs)

--- a/librelane/scripts/klayout/stream_out.py
+++ b/librelane/scripts/klayout/stream_out.py
@@ -78,7 +78,7 @@ import click
 @click.option(
     "-M",
     "--lym",
-    required=True,
+    required=False,
     help="KLayout .map (LEF/DEF layer map) file",
 )
 @click.option("-w", "--with-gds-file", "input_gds_files", multiple=True, default=[])
@@ -106,7 +106,7 @@ def stream_out(
     input_lefs: Tuple[str, ...],
     lyt: str,
     lyp: str,
-    lym: str,
+    lym: Optional[str],
     input_gds_files: Tuple[str, ...],
     seal_gds: Optional[str],
     design_name: str,
@@ -119,7 +119,8 @@ def stream_out(
         layout_options = tech.load_layout_options
         layout_options.lefdef_config.read_lef_with_def = False
         layout_options.lefdef_config.lef_files = list(input_lefs)
-        layout_options.lefdef_config.map_file = lym
+        if lym is not None:
+            layout_options.lefdef_config.map_file = lym
         # Don't produce user properties
         layout_options.lefdef_config.net_property_name = None
         layout_options.lefdef_config.instance_property_name = None

--- a/librelane/steps/klayout.py
+++ b/librelane/steps/klayout.py
@@ -58,8 +58,8 @@ class KLayoutStep(Step):
         ),
         Variable(
             "KLAYOUT_DEF_LAYER_MAP",
-            Path,
-            "A path to the KLayout LEF/DEF layer mapping (.map) file.",
+            Optional[Path],
+            "An optional path to a KLayout LEF/DEF layer mapping (.map) file. If omitted, the mapping embedded in `KLAYOUT_TECH` is used.",
             pdk=True,
         ),
     ]
@@ -93,12 +93,15 @@ class KLayoutStep(Step):
         if layer_info:
             lyp = abspath(self.config["KLAYOUT_PROPERTIES"])
             lyt = abspath(self.config["KLAYOUT_TECH"])
-            lym = abspath(self.config["KLAYOUT_DEF_LAYER_MAP"])
-            if None in [lyp, lyt, lym]:
+            lym_config = self.config["KLAYOUT_DEF_LAYER_MAP"]
+            lym = abspath(lym_config) if lym_config is not None else None
+            if None in [lyp, lyt]:
                 raise StepError(
                     "Cannot open design in KLayout as the PDK does not appear to support KLayout."
                 )
-            result += ["--lyp", lyp, "--lyt", lyt, "--lym", lym]
+            result += ["--lyp", lyp, "--lyt", lyt]
+            if lym is not None:
+                result += ["--lym", lym]
 
         if include_lefs:
             tech_lefs = self.toolbox.filter_views(self.config, self.config["TECH_LEFS"])


### PR DESCRIPTION
In the asap7 PDK the lef/def map in supplied embedded the .lyt file.
The resolves issue #999 and contributes to #995