### PR TITLE
allow PDKs to provide PDN_CFG (LLM-aided)

### DIFF
--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -156,15 +156,20 @@ proc read_pdn_cfg {} {
     set unset_list {
         DESIGN_IS_CORE
         PDN_ENABLE_MACROS_GRID
-        PDN_RAILS_LAYER
-        PDN_UPPER_LAYER
-        PDN_LOWER_LAYER
     }
     set ::env(DESIGN_IS_CORE) $::env(PDN_MULTILAYER)
     set ::env(PDN_ENABLE_MACROS_GRID) $::env(PDN_CONNECT_MACROS_TO_GRID)
-    set ::env(PDN_RAILS_LAYER) $::env(PDN_RAIL_LAYER)
-    set ::env(PDN_UPPER_LAYER) $::env(PDN_HORIZONTAL_LAYER)
-    set ::env(PDN_LOWER_LAYER) $::env(PDN_VERTICAL_LAYER)
+    # A custom PDN_CFG may not define layers used only by the default generator.
+    foreach {deprecated current} {
+        PDN_RAILS_LAYER PDN_RAIL_LAYER
+        PDN_UPPER_LAYER PDN_HORIZONTAL_LAYER
+        PDN_LOWER_LAYER PDN_VERTICAL_LAYER
+    } {
+        if { [info exists ::env($current)] } {
+            set ::env($deprecated) $::env($current)
+            lappend unset_list $deprecated
+        }
+    }
     foreach key [array names ::env] {
         if { [string match PDN_* $key] } {
             set fp_name FP_$key

--- a/librelane/steps/common_variables.py
+++ b/librelane/steps/common_variables.py
@@ -138,7 +138,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_RAIL_OFFSET",
-        Decimal,
+        Optional[Decimal],
         "The offset for the power distribution network rails for first metal layer.",
         units="µm",
         pdk=True,
@@ -146,7 +146,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_VWIDTH",
-        Decimal,
+        Optional[Decimal],
         "The strap width for the vertical layer in generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -154,7 +154,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_HWIDTH",
-        Decimal,
+        Optional[Decimal],
         "The strap width for the horizontal layer in generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -162,7 +162,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_VSPACING",
-        Decimal,
+        Optional[Decimal],
         "Intra-spacing (within a set) of vertical straps in generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -170,7 +170,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_HSPACING",
-        Decimal,
+        Optional[Decimal],
         "Intra-spacing (within a set) of horizontal straps in generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -178,7 +178,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_VPITCH",
-        Decimal,
+        Optional[Decimal],
         "Inter-distance (between sets) of vertical power straps in generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -186,7 +186,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_HPITCH",
-        Decimal,
+        Optional[Decimal],
         "Inter-distance (between sets) of horizontal power straps in generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -194,7 +194,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_VOFFSET",
-        Decimal,
+        Optional[Decimal],
         "Initial offset for sets of vertical power straps.",
         units="µm",
         pdk=True,
@@ -202,7 +202,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_HOFFSET",
-        Decimal,
+        Optional[Decimal],
         "Initial offset for sets of horizontal power straps.",
         units="µm",
         pdk=True,
@@ -210,7 +210,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_CORE_RING_VWIDTH",
-        Decimal,
+        Optional[Decimal],
         "The width for the vertical layer in the core ring of generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -218,7 +218,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_CORE_RING_HWIDTH",
-        Decimal,
+        Optional[Decimal],
         "The width for the horizontal layer in the core ring of generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -226,7 +226,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_CORE_RING_VSPACING",
-        Decimal,
+        Optional[Decimal],
         "The spacing for the vertical layer in the core ring of generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -234,7 +234,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_CORE_RING_HSPACING",
-        Decimal,
+        Optional[Decimal],
         "The spacing for the horizontal layer in the core ring of generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -242,7 +242,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_CORE_RING_VOFFSET",
-        Decimal,
+        Optional[Decimal],
         "The offset for the vertical layer in the core ring of generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -250,7 +250,7 @@ pdn_variables = [
     ),
     Variable(
         "PDN_CORE_RING_HOFFSET",
-        Decimal,
+        Optional[Decimal],
         "The offset for the horizontal layer in the core ring of generated power distribution networks.",
         units="µm",
         pdk=True,
@@ -272,14 +272,14 @@ pdn_variables = [
     ),
     Variable(
         "PDN_RAIL_LAYER",
-        str,
+        Optional[str],
         "Defines the metal layer used for PDN rails.",
         deprecated_names=["FP_PDN_RAIL_LAYER", "FP_PDN_RAILS_LAYER"],
         pdk=True,
     ),
     Variable(
         "PDN_RAIL_WIDTH",
-        Decimal,
+        Optional[Decimal],
         "Defines the width of PDN rails on the `PDN_RAIL_LAYER` layer.",
         units="µm",
         pdk=True,
@@ -287,14 +287,14 @@ pdn_variables = [
     ),
     Variable(
         "PDN_HORIZONTAL_LAYER",
-        str,
+        Optional[str],
         "Defines the horizontal PDN layer.",
         deprecated_names=["FP_PDN_HORIZONTAL_LAYER", "FP_PDN_UPPER_LAYER"],
         pdk=True,
     ),
     Variable(
         "PDN_VERTICAL_LAYER",
-        str,
+        Optional[str],
         "Defines the vertical PDN layer.",
         deprecated_names=["FP_PDN_VERTICAL_LAYER", "FP_PDN_LOWER_LAYER"],
         pdk=True,
@@ -326,6 +326,31 @@ pdn_variables = [
         pdk=True,
     ),
 ]
+
+# A custom design or PDK PDN configuration does not consume these variables,
+# so configuration loading permits them to be absent. GeneratePDN requires
+# them only when using LibreLane's generic configuration.
+default_pdn_required_variables = (
+    "PDN_RAIL_OFFSET",
+    "PDN_VWIDTH",
+    "PDN_HWIDTH",
+    "PDN_VSPACING",
+    "PDN_HSPACING",
+    "PDN_VPITCH",
+    "PDN_HPITCH",
+    "PDN_VOFFSET",
+    "PDN_HOFFSET",
+    "PDN_CORE_RING_VWIDTH",
+    "PDN_CORE_RING_HWIDTH",
+    "PDN_CORE_RING_VSPACING",
+    "PDN_CORE_RING_HSPACING",
+    "PDN_CORE_RING_VOFFSET",
+    "PDN_CORE_RING_HOFFSET",
+    "PDN_RAIL_LAYER",
+    "PDN_RAIL_WIDTH",
+    "PDN_HORIZONTAL_LAYER",
+    "PDN_VERTICAL_LAYER",
+)
 
 routing_layer_variables = [
     Variable(

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -62,6 +62,7 @@ from ..config.flow import option_variables
 from ..logging import console, debug, info, options, verbose
 from ..state import DesignFormat, State
 from .common_variables import (
+    default_pdn_required_variables,
     dpl_variables,
     grt_variables,
     io_layer_variables,
@@ -1463,8 +1464,9 @@ class GeneratePDN(OpenROADStep):
             Variable(
                 "PDN_CFG",
                 Optional[Path],
-                "A custom PDN configuration file. If not provided, the default PDN config will be used.",
+                "A custom PDN configuration file. If not provided, LibreLane's generic generator is used.",
                 deprecated_names=["FP_PDN_CFG"],
+                pdk=True,
             )
         ]
     )
@@ -1475,10 +1477,22 @@ class GeneratePDN(OpenROADStep):
     def run(self, state_in: State, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
         kwargs, env = self.extract_env(kwargs)
         if self.config["PDN_CFG"] is None:
+            missing = [
+                name
+                for name in default_pdn_required_variables
+                if self.config[name] is None
+            ]
+            if missing:
+                raise StepError(
+                    "The default PDN generator requires these PDK variables: "
+                    + ", ".join(missing)
+                )
             env["PDN_CFG"] = os.path.join(
                 get_script_dir(), "openroad", "common", "pdn_cfg.tcl"
             )
-            info(f"'PDN_CFG' not explicitly set, setting it to {env['PDN_CFG']}…")
+            info(
+                f"No custom PDN configuration provided; using LibreLane's generic configuration at {env['PDN_CFG']}…"
+            )
         views_updates, metrics_updates = super().run(state_in, env=env, **kwargs)
 
         alerts = self.alerts or []


### PR DESCRIPTION
Make PDN_CFG a PDK variable and allow the generic PDN parameters to be omitted when a custom configuration is provided.

The bigger chance here is allowing the PDN parameters to be emitted when a PDN_CFG is provided.  We could instead extract the PDN parameters from the script, but I wasn't confident I could do that correctly.

#997, #995