### PR TITLE
WIP: Fix unit handling at LibreLane tool boundaries (LLM-aided)

### DIFF
--- a/librelane/common/toolbox.py
+++ b/librelane/common/toolbox.py
@@ -513,6 +513,8 @@ class Toolbox(object):
     ) -> Optional[Decimal]:
         """
         Extract the voltage from the default operating conditions of a liberty file.
+        Liberty files with an explicit voltage unit other than one volt are
+        rejected because the returned value is passed to tools that expect volts.
 
         Returns ``None`` if and only if the ``default_operating_conditions`` key
         does not exist and the number of operating conditions enumerated is not
@@ -529,6 +531,13 @@ class Toolbox(object):
         for child in ast.children:
             if child.id == "default_operating_conditions":
                 default_operating_conditions_id = child.value
+            if child.id == "voltage_unit":
+                voltage_unit = str(child.value).strip().strip('"')
+                if re.fullmatch(r"1(?:\.0+)?[vV]", voltage_unit) is None:
+                    raise ValueError(
+                        f"Unsupported Liberty voltage unit '{voltage_unit}' in "
+                        f"'{input_lib}': expected 1V"
+                    )
             if child.id == "operating_conditions":
                 operating_conditions_raw[child.args[0]] = child
 

--- a/librelane/scripts/base.sdc
+++ b/librelane/scripts/base.sdc
@@ -58,6 +58,7 @@ set_driving_cell \
     -pin [lindex [split $::env(SYNTH_CLK_DRIVING_CELL) "/"] 1] \
     $clk_input
 
+# OUTPUT_CAP_LOAD is in fF; SDC capacitance arguments are in pF.
 set cap_load [expr $::env(OUTPUT_CAP_LOAD) / 1000.0]
 puts "\[INFO] Setting load to: $cap_load"
 set_load $cap_load [all_outputs]

--- a/librelane/scripts/magic/spice_rcx.tcl
+++ b/librelane/scripts/magic/spice_rcx.tcl
@@ -68,6 +68,7 @@ puts "capacitance threshold: $::env(MAGIC_RCX_CTHRESH)"
 # > "I use ext2spice lvs as a shorthand for "set ext2spice parameters to something sane", after which I
 # > re-establish the options that I want."
 ext2spice lvs
+# MAGIC_RCX_CTHRESH and Magic's cthresh argument are both in fF.
 ext2spice cthresh $::env(MAGIC_RCX_CTHRESH)
 ext2spice extresist on
 ext2spice -f ngspice -o $netlist $::env(DESIGN_NAME).ext

--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -19,6 +19,46 @@ source $::env(_TCL_ENV_IN)
 source $::env(SCRIPTS_DIR)/openroad/common/set_global_connections.tcl
 
 namespace eval lln {
+    variable first_liberty_unit_scales
+
+    proc set_sta_cmd_units {} {
+        # Bare numeric arguments to STA commands use mutable command units.
+        # In particular, OpenSTA replaces these units when it reads the first
+        # Liberty library. Restore LibreLane's convention at each STA command
+        # boundary instead of relying on earlier process state.
+        set_cmd_units \
+            -time ns \
+            -capacitance pF \
+            -current mA \
+            -voltage V \
+            -resistance kOhm \
+            -distance um
+    }
+
+    proc capture_first_liberty_units {} {
+        variable first_liberty_unit_scales
+        if {[info exists first_liberty_unit_scales]} {
+            return
+        }
+
+        # OpenSTA copies the first Liberty's units into its command-unit state.
+        # Preserve the exact scales before sta_cmd restores LibreLane's units.
+        set first_liberty_unit_scales [dict create]
+        foreach unit {time capacitance resistance voltage current power distance} {
+            dict set first_liberty_unit_scales $unit [sta::unit_scale $unit]
+        }
+    }
+
+    proc set_first_liberty_units {} {
+        variable first_liberty_unit_scales
+        if {![info exists first_liberty_unit_scales]} {
+            error "First-Liberty units were requested before reading a Liberty library."
+        }
+        dict for {unit scale} $first_liberty_unit_scales {
+            sta::set_cmd_unit_scale $unit $scale
+        }
+    }
+
     proc get_corner_names {} {
         # returns: names as a Tcl list, compatible with both OpenSTA 2 and 3
         if {[string length [namespace which sta::scenes]] != 0} {
@@ -60,6 +100,13 @@ namespace eval lln {
         }
     }
 };
+
+# Restore LibreLane's STA command units immediately before running a command
+# whose bare numeric arguments or results depend on those units.
+proc sta_cmd {cmd args} {
+    lln::set_sta_cmd_units
+    return [$cmd {*}$args]
+}
 
 proc string_in_file {file_path substring} {
     set f [open $file_path r]
@@ -111,7 +158,7 @@ proc read_current_sdc {} {
     }
 
     puts "Reading design constraints file at '$::env(_SDC_IN)'…"
-    if {[catch {read_sdc $::env(_SDC_IN)} errmsg]} {
+    if {[catch {sta_cmd read_sdc $::env(_SDC_IN)} errmsg]} {
         puts stderr $errmsg
         exit 1
     }
@@ -243,6 +290,8 @@ proc read_timing_info {args} {
         }
     }
 
+    lln::capture_first_liberty_units
+
     set blackbox_wildcard {/// sta-blackbox}
     foreach nl $::env(_CURRENT_CORNER_NETLISTS) {
         puts "Reading macro netlist at '$nl'…"
@@ -310,6 +359,7 @@ proc read_spefs {} {
             }
         }
     }
+
 }
 
 proc read_pnr_libs {args} {
@@ -351,6 +401,8 @@ proc read_pnr_libs {args} {
             }
         }
     }
+
+    lln::capture_first_liberty_units
 }
 
 proc read_tech_lef {{tlef_key "TECH_LEF"}} {
@@ -561,7 +613,7 @@ proc write_views {args} {
 
     if { [info exists ::env(SAVE_SDC)] } {
         puts "Writing timing constraints to '$::env(SAVE_SDC)'…"
-        write_sdc -no_timestamp $::env(SAVE_SDC)
+        sta_cmd write_sdc -no_timestamp $::env(SAVE_SDC)
     }
 
     if { [info exists ::env(SAVE_SPEF)] } {
@@ -577,7 +629,7 @@ proc write_views {args} {
     if { [info exists ::env(SAVE_SDF)] } {
         if { [llength [lln::get_corner_names]] <= 1 } {
             puts "Writing SDF to '$::env(SAVE_SDF)'…"
-            write_sdf -include_typ -divider . $::env(SAVE_SDF)
+            sta_cmd write_sdf -include_typ -divider . $::env(SAVE_SDF)
         }
     }
 }
@@ -587,7 +639,7 @@ proc write_sdfs {} {
         puts "Writing SDF files for all corners…"
         foreach corner_name [lln::get_corner_names] {
             set target $::env(_SDF_SAVE_DIR)/$::env(DESIGN_NAME)__$corner_name.sdf
-            write_sdf -include_typ -divider . -corner $corner_name $target
+            sta_cmd write_sdf -include_typ -divider . -corner $corner_name $target
         }
     }
 }
@@ -603,9 +655,9 @@ proc write_libs {} {
             set target $::env(_LIB_SAVE_DIR)/$::env(DESIGN_NAME)__$corner_name.lib
             puts "Writing timing models for the $corner_name corner to $target…"
             if {[string length [namespace which sta::scenes]] != 0} {
-                write_timing_model -scene $corner_name $target
+                sta_cmd write_timing_model -scene $corner_name $target
             } else {
-                write_timing_model -corner $corner_name $target
+                sta_cmd write_timing_model -corner $corner_name $target
             }
         }
     }

--- a/librelane/scripts/openroad/common/set_rc.tcl
+++ b/librelane/scripts/openroad/common/set_rc.tcl
@@ -159,8 +159,13 @@ proc set_diff {setA setB} {
 # 4. If (1) doesn't override the corners at all, call set_wire_rc without -corner, to ensure the default behavior
 # 5. If (1) does override (some) corners, we must use set_wire_rc with -corner, becuase otherwise set_wire_rc will set the default techlef value for all existing corners
 
+# LAYERS_RC and VIAS_R use the command units established by the first Liberty.
+lln::set_first_liberty_units
 set corners_with_custom_layer_rc [set_layers_custom_rc]
 set corners_with_custom_via_r [set_via_custom_r]
+
+# Generated RC values are converted to LibreLane's canonical command units.
+lln::set_sta_cmd_units
 set corners_without_custom_layer_rc [set_diff [lln::get_corner_names] $corners_with_custom_layer_rc]
 set corners_without_custom_via_r [set_diff [lln::get_corner_names] $corners_with_custom_via_r]
 

--- a/librelane/scripts/openroad/cts.tcl
+++ b/librelane/scripts/openroad/cts.tcl
@@ -93,7 +93,8 @@ set_propagated_clock [all_clocks]
 estimate_parasitics -placement
 puts "\[INFO\] Repairing long wires on clock nets…"
 # CTS leaves a long wire from the pad to the clock tree root.
-repair_clock_nets -max_wire_length $::env(CTS_CLK_MAX_WIRE_LENGTH)
+# Unlike most OpenROAD distance arguments, -max_wire_length uses STA command units.
+sta_cmd repair_clock_nets -max_wire_length $::env(CTS_CLK_MAX_WIRE_LENGTH)
 
 estimate_parasitics -placement
 write_views

--- a/librelane/scripts/openroad/repair_design.tcl
+++ b/librelane/scripts/openroad/repair_design.tcl
@@ -53,13 +53,14 @@ if { [info exists ::env(DESIGN_REPAIR_BUFFER_GAIN)] } {
     lappend arg_list -buffer_gain $::env(DESIGN_REPAIR_BUFFER_GAIN)
 }
 # Repair Design
-log_cmd repair_design {*}$arg_list
+sta_cmd log_cmd repair_design {*}$arg_list
 
 if { $::env(DESIGN_REPAIR_TIE_FANOUT) } {
+    # Unlike most OpenROAD distance arguments, -separation uses STA command units.
     # repair tie lo fanout
-    repair_tie_fanout -verbose -separation $::env(DESIGN_REPAIR_TIE_SEPARATION) $::env(SYNTH_TIELO_CELL)
+    sta_cmd repair_tie_fanout -verbose -separation $::env(DESIGN_REPAIR_TIE_SEPARATION) $::env(SYNTH_TIELO_CELL)
     # repair tie hi fanout
-    repair_tie_fanout -verbose -separation $::env(DESIGN_REPAIR_TIE_SEPARATION) $::env(SYNTH_TIEHI_CELL)
+    sta_cmd repair_tie_fanout -verbose -separation $::env(DESIGN_REPAIR_TIE_SEPARATION) $::env(SYNTH_TIEHI_CELL)
 }
 
 report_floating_nets -verbose
@@ -74,4 +75,3 @@ estimate_parasitics -placement
 
 
 write_views
-

--- a/librelane/scripts/openroad/repair_design_postgrt.tcl
+++ b/librelane/scripts/openroad/repair_design_postgrt.tcl
@@ -42,7 +42,7 @@ if { [info exists ::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)] } {
 if { [info exists ::env(GRT_DESIGN_REPAIR_BUFFER_GAIN)] } {
     lappend arg_list -buffer_gain $::env(GRT_DESIGN_REPAIR_BUFFER_GAIN)
 }
-log_cmd repair_design {*}$arg_list
+sta_cmd log_cmd repair_design {*}$arg_list
 
 # Re-DPL and GRT
 source $::env(SCRIPTS_DIR)/openroad/common/dpl.tcl

--- a/librelane/scripts/openroad/rsz_timing_postcts.tcl
+++ b/librelane/scripts/openroad/rsz_timing_postcts.tcl
@@ -50,11 +50,11 @@ append_if_exists_argument hold_args PL_RESIZER_HOLD_REPAIR_TNS_PCT -repair_tns
 append_if_exists_argument hold_args PL_RESIZER_HOLD_MAX_UTIL_PCT -max_utilization
 
 if { $::env(PL_RESIZER_FIX_HOLD_FIRST) == 1 } {
-    log_cmd repair_timing {*}$hold_args
-    log_cmd repair_timing {*}$setup_args
+    sta_cmd log_cmd repair_timing {*}$hold_args
+    sta_cmd log_cmd repair_timing {*}$setup_args
 } else {
-    log_cmd repair_timing {*}$setup_args
-    log_cmd repair_timing {*}$hold_args
+    sta_cmd log_cmd repair_timing {*}$setup_args
+    sta_cmd log_cmd repair_timing {*}$hold_args
 }
 
 # Legalize

--- a/librelane/scripts/openroad/rsz_timing_postgrt.tcl
+++ b/librelane/scripts/openroad/rsz_timing_postgrt.tcl
@@ -53,11 +53,11 @@ append_if_exists_argument hold_args GRT_RESIZER_HOLD_REPAIR_TNS_PCT -repair_tns
 append_if_exists_argument hold_args GRT_RESIZER_HOLD_MAX_UTIL_PCT -max_utilization
 
 if { $::env(GRT_RESIZER_FIX_HOLD_FIRST) == 1 } {
-    log_cmd repair_timing {*}$hold_args
-    log_cmd repair_timing {*}$setup_args
+    sta_cmd log_cmd repair_timing {*}$hold_args
+    sta_cmd log_cmd repair_timing {*}$setup_args
 } else {
-    log_cmd repair_timing {*}$setup_args
-    log_cmd repair_timing {*}$hold_args
+    sta_cmd log_cmd repair_timing {*}$setup_args
+    sta_cmd log_cmd repair_timing {*}$hold_args
 }
 
 # Re-DPL and GRT

--- a/librelane/scripts/openroad/sta/check_macro_instances.tcl
+++ b/librelane/scripts/openroad/sta/check_macro_instances.tcl
@@ -13,14 +13,6 @@
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 
-set_cmd_units\
-    -time ns\
-    -capacitance pF\
-    -current mA\
-    -voltage V\
-    -resistance kOhm\
-    -distance um
-
 set sta_report_default_digits 6
 
 read_timing_info

--- a/librelane/scripts/openroad/sta/corner.tcl
+++ b/librelane/scripts/openroad/sta/corner.tcl
@@ -23,14 +23,6 @@
 
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 
-set_cmd_units\
-    -time ns\
-    -capacitance pF\
-    -current mA\
-    -voltage V\
-    -resistance kOhm\
-    -distance um
-
 set sta_report_default_digits 6
 
 if { [namespace exists ::ord] } {
@@ -59,6 +51,10 @@ set clocks [sta::sort_by_name [sta::all_clocks]]
 if {  [info exist ::env(STA_EXTRA_CORNER_TCL_FILE)] } {
     source $::env(STA_EXTRA_CORNER_TCL_FILE)
 }
+
+# Reports and metric-producing STA queries below use command-unit values. The
+# optional user Tcl above may have changed those units.
+lln::set_sta_cmd_units
 
 puts "%OL_CREATE_REPORT min.rpt"
 puts "\n==========================================================================="

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -276,6 +276,7 @@ def synthesize(
     sdc_path = os.path.join(step_dir, "synthesis.abc.sdc")
     with open(sdc_path, "w") as f:
         print(f"set_driving_cell {config['SYNTH_DRIVING_CELL']}", file=f)
+        # OUTPUT_CAP_LOAD and ABC's set_load argument are both in fF.
         print(f"set_load {config['OUTPUT_CAP_LOAD']}", file=f)
 
     ys.log(f"[INFO] Using SDC file '{sdc_path}' for ABC…")


### PR DESCRIPTION
This is a first attempt at being explicit about what units and getting used and setting the units explicitly before interacting OpenROAD. I leaned heavily on an LLM to find the places where changes were needed, and I'm not at all confident that the changes aren't breaking things.

Really I don't understand the codebase well enough to be making these changes, but they are enabling me to use asap7 locally so I thought it was worth creating this as a pull request at least as a starting point.

The main changes are:
 `set_sta_cmd_units` is being used before any openroad commands that assume values have the opensta units.
 `set_first_liberty_units` is used as a hacky way of supporting the LAYER_RC and VIA_R commands which use the units defined in the liberty files.

#996 #995