### PR TITLE
docs: fix typo in design entry section

### DIFF
--- a/docs/source/getting_started/newcomers/index.md
+++ b/docs/source/getting_started/newcomers/index.md
@@ -18,7 +18,7 @@ powerful EDA (Electronic Design Automation) tools that facilitate the
 implementation of the design. The following are examples of steps needed to
 realize an ASIC.
 
-* Design Entry: The design is described is described using a
+* Design Entry: The design is described using a
   {term}`hardware description language <HDL>` such as {term}`Verilog`.
   For digital design, modeling is typically done at the
   {term}`register transfer level <RTL>`, 


### PR DESCRIPTION
### Summary
Fixes a minor typo in the **Getting Started/newcomer's tutorial/** documentation where the phrase `is described` was accidentally duplicated.