### PR TITLE
Fix curl command for Nix installation on macOS

### DIFF
--- a/docs/source/installation/nix_installation/installation_macos.md
+++ b/docs/source/installation/nix_installation/installation_macos.md
@@ -29,7 +29,7 @@ Intel-based Mac, you have two options:
 Simply run this (entire) command in `Terminal.app`:
 
 ```console
-$ curl --proto '=https' --tlsv1.2 -fsSL https://artifacts.nixos.org/nix-installer | sh -s -- install--no-confirm --extra-conf "
+$ curl --proto '=https' --tlsv1.2 -fsSL https://artifacts.nixos.org/nix-installer | sh -s -- install --no-confirm --extra-conf "
     extra-substituters = https://nix-cache.fossi-foundation.org
     extra-trusted-public-keys = nix-cache.fossi-foundation.org:3+K59iFwXqKsL7BNu6Guy0v+uTlwsxYQxjspXzqLYQs=
     extra-experimental-features = nix-command flakes


### PR DESCRIPTION
The current curl command for Nix installation on macOS causes a shell error.