### PR TITLE
docs: fix erroneous reference to non-existent "Figure 1" in newcomers' guide

### DIFF
--- a/docs/source/getting_started/migrants/index.md
+++ b/docs/source/getting_started/migrants/index.md
@@ -27,6 +27,7 @@ entirely backwards compatible, with some conveniences:
   design at certain parts of flows, without worrying about surprises related
   to state variables missing.
 
+(fig-configurable-flow)=
 ```{figure} ./configurable_flow.webp
 Writing custom flows and steps using LibreLane
 ```

--- a/docs/source/getting_started/newcomers/index.md
+++ b/docs/source/getting_started/newcomers/index.md
@@ -56,7 +56,7 @@ LibreLane is a powerful and versatile infrastructure library that enables the
 construction of digital ASIC physical implementation flows based on open-source
 and commercial EDA tools. It includes a reference flow ({flow}`Classic`) that is
 constructed entirely using open-source EDA tools — abstracting their behavior
-and allowing the user to configure them using a single file (See Figure 1).
+and allowing the user to configure them using a single file (See {ref}`Figure 1 <fig-configurable-flow>`).
 LibreLane also supports extending or modifying flows using Python scripts and
 utilities. Here are some of the key benefits of using LibreLane:
 

--- a/docs/source/getting_started/newcomers/index.md
+++ b/docs/source/getting_started/newcomers/index.md
@@ -56,7 +56,7 @@ LibreLane is a powerful and versatile infrastructure library that enables the
 construction of digital ASIC physical implementation flows based on open-source
 and commercial EDA tools. It includes a reference flow ({flow}`Classic`) that is
 constructed entirely using open-source EDA tools — abstracting their behavior
-and allowing the user to configure them using a single file (See {ref}`Figure 1 <fig-configurable-flow>`).
+and allowing the user to configure them using a single file (See {ref}`fig-configurable-flow`).
 LibreLane also supports extending or modifying flows using Python scripts and
 utilities. Here are some of the key benefits of using LibreLane:
 


### PR DESCRIPTION

Updates the `"Figure 1"` text reference in `index.md` (`What is LibreLane?` section) to use an internal MyST cross-reference (`{ref}`) pointing directly to the figure's target anchor.


#### **Changes Included**
* Added an anchor label to the target configuration flow figure (`configurable_flow.webp`).
* Replaced the static text `(See Figure 1)` in `index.md` with `{ref}` linking to the figure target.