### PR TITLE
hotfix: potential integer division of TIME_DERATING_CONSTRAINT in SDC files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,36 @@ Style Notes
 
 -->
 
+# 3.0.7
+
+## Steps
+
+* `OpenROAD.*`
+
+  * Fixed issue reported by [@Nexlab-One](https://github.com/Nexlab-One) where
+    `TIME_DERATING_CONSTRAINT` was integer-divided instead of float-divided, and
+    additionally `IO_DELAY_CONSTRAINT` if specified using old syntax (`IO_PCT`).
+
+## Misc. Enhancements/Bugfixes
+
+* `librelane.steps.TclStep.value_to_tcl`
+  * Fixed long-incorrect docstring.
+  * `Decimal` values that are integers are now always output with a `.0` to
+    pre-empt any further integer division issues (as well as backport the fix to
+    any user-written SDC files).
+
+* `librelane.config.pdk_compat`
+  * For extra resilience, `TIME_DERATING_CONSTRAINT`, `IO_DELAY_CONSTRAINTS` are
+    now both set as floats.
+
+# 3.0.6
+
+## Misc. Enhancements/Bugfixes
+
+* Slight internal rework of `librelane.common.metrics` that should not affect
+  its API, also fixing "folders" to "directories" in documentation where
+  appropriate.
+
 # 3.0.5
 
 ## Tool Updates

--- a/librelane/config/pdk_compat.py
+++ b/librelane/config/pdk_compat.py
@@ -325,9 +325,9 @@ def migrate_old_config(config: Mapping[str, Any]) -> Dict[str, Any]:
         if "CLOCK_TRANSITION_CONSTRAINT" not in config:
             new["CLOCK_TRANSITION_CONSTRAINT"] = 0.15
         if "TIME_DERATING_CONSTRAINT" not in config:
-            new["TIME_DERATING_CONSTRAINT"] = 5
+            new["TIME_DERATING_CONSTRAINT"] = 5.0
         if "IO_DELAY_CONSTRAINT" not in config:
-            new["IO_DELAY_CONSTRAINT"] = 20
+            new["IO_DELAY_CONSTRAINT"] = 20.0
 
         # Unspecififed is fine
         # if "FP_IO_MIN_DISTANCE" not in config:

--- a/librelane/examples/spm/src/impl.sdc
+++ b/librelane/examples/spm/src/impl.sdc
@@ -69,5 +69,5 @@ puts "\[INFO] Setting clock transition to: $::env(CLOCK_TRANSITION_CONSTRAINT)"
 set_clock_transition $::env(CLOCK_TRANSITION_CONSTRAINT) $clocks
 
 puts "\[INFO] Setting timing derate to: $::env(TIME_DERATING_CONSTRAINT)%"
-set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
-set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
+set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]]
+set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]]

--- a/librelane/examples/spm/src/signoff.sdc
+++ b/librelane/examples/spm/src/signoff.sdc
@@ -64,5 +64,5 @@ puts "\[INFO] Setting clock uncertainty to: 0.1"
 set_clock_uncertainty 0.1 $clocks
 
 puts "\[INFO] Setting timing derate to: $::env(TIME_DERATING_CONSTRAINT)%"
-set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
-set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
+set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]]
+set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]]

--- a/librelane/scripts/base.sdc
+++ b/librelane/scripts/base.sdc
@@ -69,8 +69,8 @@ puts "\[INFO] Setting clock transition to: $::env(CLOCK_TRANSITION_CONSTRAINT)"
 set_clock_transition $::env(CLOCK_TRANSITION_CONSTRAINT) $clocks
 
 puts "\[INFO] Setting timing derate to: $::env(TIME_DERATING_CONSTRAINT)%"
-set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
-set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
+set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]]
+set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]]
 
 if { [info exists ::env(OPENLANE_SDC_IDEAL_CLOCKS)] && $::env(OPENLANE_SDC_IDEAL_CLOCKS) } {
     unset_propagated_clock [all_clocks]

--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -95,8 +95,8 @@ proc read_current_sdc {} {
 
     # Compatibility Layer for Deprecated Variables That May Still Be Used By
     # User Files
-    set ::env(IO_PCT) [expr $::env(IO_DELAY_CONSTRAINT) / 100]
-    set ::env(SYNTH_TIMING_DERATE) [expr $::env(TIME_DERATING_CONSTRAINT) / 100]
+    set ::env(IO_PCT) [expr $::env(IO_DELAY_CONSTRAINT) / 100.0]
+    set ::env(SYNTH_TIMING_DERATE) [expr $::env(TIME_DERATING_CONSTRAINT) / 100.0]
     set ::env(SYNTH_MAX_FANOUT) $::env(MAX_FANOUT_CONSTRAINT)
     set ::env(SYNTH_CLOCK_UNCERTAINTY) $::env(CLOCK_UNCERTAINTY_CONSTRAINT)
     set ::env(SYNTH_CLOCK_TRANSITION) $::env(CLOCK_TRANSITION_CONSTRAINT)

--- a/librelane/steps/tclstep.py
+++ b/librelane/steps/tclstep.py
@@ -62,10 +62,10 @@ class TclStep(Step):
         """
         Converts an arbitrary Python value to Tcl as follows:
 
-        * If the value is an instance of a dataclass, it is serialized as a JSON object.
+        * If the value is a dict, the keys and values are escaped recursively
+            using: :meth:`TclUtils.join`.
+        * If the value is an instance of a dataclass, it is treated as a dict.
         * If the value is a list, it is joined using :meth:`TclUtils.join`.
-        * If the value is a dict, the keys and values are escaped recursively using:
-            joined using :meth:`TclUtils.join`.
         * If the value is an Enum, its name is returned.
         * If the value is Boolean, "1" is returned for True and "0" for False.
         * If the value is numeric, it is converted to a string.
@@ -89,7 +89,9 @@ class TclStep(Step):
         elif isinstance(value, bool):
             return "1" if value else "0"
         elif isinstance(value, Decimal):
-            return str(value)  # f"{value:e}"
+            if value.to_integral_value() == value:
+                return f"{value:.1f}"
+            return str(value)
         elif isinstance(value, int):
             return str(value)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.6"
+version = "3.0.7"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
TIME_DERATING_CONSTRAINT can be set as an integer and is then divided by 100 in Tcl's expr, which the result is always 0. A fix was added to the default SDC files, and mitigations were peppered throughout the rest of the codebase.

---

Resolves #1013 