### PR TITLE
fix: `abc -fast` being used with Yosys ≥ 0.68

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,15 @@ Style Notes
 
 -->
 
+# 3.0.8
+
+## Steps
+
+* `Yosys.*Synthesis`
+
+  * Added compatibility with Yosys 0.67 and higher (non-bundled versions, thus
+    best-effort) by gating relevant commands.
+
 # 3.0.7
 
 ## Steps

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -38,7 +38,7 @@ from typing import List, Optional
 
 import click
 
-from ys_common import ys, yosys_version
+from ys_common import ys, yosys_version_at_least
 from construct_abc_script import ABCScriptCreator
 
 
@@ -226,7 +226,7 @@ def librelane_synth(
     librelane_opt(d, fast=True)
 
     abc_pass = ["abc"]
-    if yosys_version() < (0, 68):
+    if not yosys_version_at_least(0, 68):
         abc_pass.append("-fast")
     if abc_dff:
         abc_pass.append("-dff")

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -225,9 +225,7 @@ def librelane_synth(
     librelane_opt(d, fast=True)
     librelane_opt(d, fast=True)
 
-    d.run_pass(
-        "abc", "-fast", *(["-dff"] if abc_dff else [])
-    )  # Run ABC with fast settings
+    d.run_pass("abc", *(["-dff"] if abc_dff else []))
     d.run_pass("opt", "-fast")  # MORE fast optimization
 
     # Checks and Stats

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -38,7 +38,7 @@ from typing import List, Optional
 
 import click
 
-from ys_common import ys
+from ys_common import ys, yosys_version
 from construct_abc_script import ABCScriptCreator
 
 
@@ -225,7 +225,12 @@ def librelane_synth(
     librelane_opt(d, fast=True)
     librelane_opt(d, fast=True)
 
-    d.run_pass("abc", *(["-dff"] if abc_dff else []))
+    abc_pass = ["abc"]
+    if yosys_version() < (0, 68):
+        abc_pass.append("-fast")
+    if abc_dff:
+        abc_pass.append("-dff")
+    d.run_pass(*abc_pass)
     d.run_pass("opt", "-fast")  # MORE fast optimization
 
     # Checks and Stats

--- a/librelane/scripts/pyosys/ys_common.py
+++ b/librelane/scripts/pyosys/ys_common.py
@@ -45,7 +45,7 @@ _yosys_version_extracted: Optional[Tuple[int, int]] = None
 def yosys_version_at_least(*target: Tuple[int, ...]) -> Tuple[int, int]:
     """
     check if version is >= the target components, i.e.
-    
+
     yosys_version_at_least(0, 68) checks if the verison >= 0.68
     """
     global _yosys_version_extracted

--- a/librelane/scripts/pyosys/ys_common.py
+++ b/librelane/scripts/pyosys/ys_common.py
@@ -43,8 +43,8 @@ def yosys_version() -> Tuple[int, int]:
     raw = ys.yosys_maybe_version()
     if match := _YOSYS_VERSION_RX.search(raw):
         return (int(match.group(1)), int(match.group(2)))
-    ys.log(
-        "* Warning: Could not identify Yosys version. "
+    ys.log_warning(
+        "Could not identify Yosys version. "
         "Defaulting to the latest on all gated behavior.\n"
     )
     return (999, 999)

--- a/librelane/scripts/pyosys/ys_common.py
+++ b/librelane/scripts/pyosys/ys_common.py
@@ -18,9 +18,7 @@
 import os
 import re
 import sys
-from typing import Iterable, List, Tuple, Union
-
-_YOSYS_VERSION_RX = re.compile(r"^\s*Yosys (\d+)\.(\d+)")
+from typing import Iterable, List, Optional, Tuple, Union
 
 try:
     from pyosys import libyosys as ys
@@ -29,25 +27,40 @@ except ImportError:
         # flake8: noqa F401
         import libyosys
 
-        ys.log_error("Current versions of LibreLane require Yosys 0.59.1 or higher.")
+        print(
+            "Current versions of LibreLane require Yosys 0.59.1 or higher.",
+            file=sys.stderr,
+        )
         exit(-1)
     except ImportError:
-        ys.log_error(
+        print(
             "Failed to import pyosys -- make sure Yosys is compiled with ENABLE_PYTHON set to 1.",
             file=sys.stderr,
         )
         exit(-1)
 
+_yosys_version_extracted: Optional[Tuple[int, int]] = None
 
-def yosys_version() -> Tuple[int, int]:
-    raw = ys.yosys_maybe_version()
-    if match := _YOSYS_VERSION_RX.search(raw):
-        return (int(match.group(1)), int(match.group(2)))
-    ys.log_warning(
-        "Could not identify Yosys version. "
-        "Defaulting to the latest on all gated behavior.\n"
-    )
-    return (999, 999)
+
+def yosys_version_at_least(*target: Tuple[int, ...]) -> Tuple[int, int]:
+    """
+    check if version is >= the target components, i.e.
+    
+    yosys_version_at_least(0, 68) checks if the verison >= 0.68
+    """
+    global _yosys_version_extracted
+    yosys_version_rx = re.compile(r"^\s*Yosys (\d+)\.(\d+)")
+    if _yosys_version_extracted is None:
+        _yosys_version_extracted = (999, 999)
+        try:
+            match = yosys_version_rx.search(ys.Globals.yosys_version_str)
+            _yosys_version_extracted = (int(match.group(1)), int(match.group(3)))
+        except Exception:
+            ys.log_warning(
+                "Could not identify Yosys version. "
+                "Defaulting to the latest version's behavior on all code.\n"
+            )
+    return _yosys_version_extracted >= target
 
 
 def _Design_run_pass(self, *command):
@@ -85,9 +98,9 @@ def _Design_read_verilog_files(
         chparams[param] = value
         slang_chparam_args.append(f"-G{param}={value}")
 
-    ys.log("use_slang" if use_slang else "wtaf")
     if use_slang:
-        self.run_pass("plugin", "-i", "slang")
+        if not yosys_version_at_least(0, 67):
+            self.run_pass("plugin", "-i", "slang")
         self.run_pass(
             "read_slang",
             "--top",

--- a/librelane/scripts/pyosys/ys_common.py
+++ b/librelane/scripts/pyosys/ys_common.py
@@ -54,7 +54,7 @@ def yosys_version_at_least(*target: Tuple[int, ...]) -> Tuple[int, int]:
         _yosys_version_extracted = (999, 999)
         try:
             match = yosys_version_rx.search(ys.Globals.yosys_version_str)
-            _yosys_version_extracted = (int(match.group(1)), int(match.group(3)))
+            _yosys_version_extracted = (int(match.group(1)), int(match.group(2)))
         except Exception:
             ys.log_warning(
                 "Could not identify Yosys version. "

--- a/librelane/scripts/pyosys/ys_common.py
+++ b/librelane/scripts/pyosys/ys_common.py
@@ -16,8 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import re
 import sys
-from typing import Iterable, List, Union
+from typing import Iterable, List, Tuple, Union
+
+_YOSYS_VERSION_RX = re.compile(r"^\s*Yosys (\d+)\.(\d+)")
 
 try:
     from pyosys import libyosys as ys
@@ -34,6 +37,17 @@ except ImportError:
             file=sys.stderr,
         )
         exit(-1)
+
+
+def yosys_version() -> Tuple[int, int]:
+    raw = ys.yosys_maybe_version()
+    if match := _YOSYS_VERSION_RX.search(raw):
+        return (int(match.group(1)), int(match.group(2)))
+    ys.log(
+        "* Warning: Could not identify Yosys version. "
+        "Defaulting to the latest on all gated behavior.\n"
+    )
+    return (999, 999)
 
 
 def _Design_run_pass(self, *command):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.7"
+version = "3.0.8"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
- add new function called yosys_version_at_least which checks if the current yosys version is >= the version components, the latter passed as integer variable arguments
- only use `abc -fast` for Yosys versions < 0.68
- only use `plugin -i slang` for Yosys versions < 0.67

---

Fixes #1012