### PR TITLE
fix: parse final chk.rpt for synthesis check errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,15 @@ Style Notes
 
 -->
 
+# 3.0.10
+
+## Steps
+
+* `Yosys.*Synthesis`
+
+  * Fixed the `synthesis__check_error__count` error metric only counting
+    pre-synthesis check errors.
+
 # 3.0.9
 
 ## Steps

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -594,15 +594,19 @@ class SynthesisCommon(VerilogStep):
         ]
         metric_updates["design__instance_unmapped__count"] = sum(unmapped_cells)
 
-        check_error_count_file = os.path.join(self.step_dir, "reports", "chk.rpt")
+        check_report_files = [
+            os.path.join(self.step_dir, "reports", "pre_synth_chk.rpt"),
+            os.path.join(self.step_dir, "reports", "chk.rpt"),
+        ]
         metric_updates["synthesis__check_error__count"] = 0
-        if os.path.exists(check_error_count_file):
-            metric_updates["synthesis__check_error__count"] = _parse_yosys_check(
-                open(check_error_count_file),
-                self.config["TRISTATE_CELLS"],
-                self.config["SYNTH_CHECKS_ALLOW_TRISTATE"],
-                self.config["SYNTH_ELABORATE_ONLY"],
-            )
+        for check_error_count_file in check_report_files:
+            if os.path.exists(check_error_count_file):
+                metric_updates["synthesis__check_error__count"] += _parse_yosys_check(
+                    open(check_error_count_file),
+                    self.config["TRISTATE_CELLS"],
+                    self.config["SYNTH_CHECKS_ALLOW_TRISTATE"],
+                    self.config["SYNTH_ELABORATE_ONLY"],
+                )
 
         view_updates[DesignFormat.NETLIST] = Path(out_file)
 

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -594,9 +594,7 @@ class SynthesisCommon(VerilogStep):
         ]
         metric_updates["design__instance_unmapped__count"] = sum(unmapped_cells)
 
-        check_error_count_file = os.path.join(
-            self.step_dir, "reports", "pre_synth_chk.rpt"
-        )
+        check_error_count_file = os.path.join(self.step_dir, "reports", "chk.rpt")
         metric_updates["synthesis__check_error__count"] = 0
         if os.path.exists(check_error_count_file):
             metric_updates["synthesis__check_error__count"] = _parse_yosys_check(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.9"
+version = "3.0.10"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
Fixes `synthesis__check_error__count` counting only pre-synthesis check reports instead both pre-and-post synthesis checks.

Original text follows:

----

Fixes #824 

`Checker.YosysSynthChecks` read errors from `pre_synth_chk.rpt` (written during proc), but users inspect `chk.rpt` (written at the end of synthesis). Parse `chk.rpt` so the metric matches the report file.

## Test plan
- [x] CI lint + unit tests pass
- [x] CI smoketest / design tests pass