### PR TITLE
fix: handle OpenSTA scenes bridged as objects in io.tcl

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,15 @@ Style Notes
 
 -->
 
+# 3.0.12
+
+## Steps
+
+* `OpenROAD.*`
+
+  * Added support for OpenSTA 3.1 in a backwards-compatible manner (Thanks,
+    [@jalcim](https://github.com/jalcim)!)
+
 # 3.0.11
 
 ## Tool Updates

--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -19,11 +19,23 @@ source $::env(_TCL_ENV_IN)
 source $::env(SCRIPTS_DIR)/openroad/common/set_global_connections.tcl
 
 namespace eval lln {
+    proc scene_name {scene} {
+        # OpenSTA >= 3.1 (commit 998806cb, 2026-06-30) bridges scenes as SWIG
+        # objects instead of strings. Older OpenSTA 3 bridges them as strings,
+        # in which case the value already is the name.
+        if { [sta::is_object $scene] } {
+            return [sta::get_property $scene name]
+        }
+        return $scene
+    }
     proc get_corner_names {} {
         # returns: names as a Tcl list, compatible with both OpenSTA 2 and 3
         if {[string length [namespace which sta::scenes]] != 0} {
-            # scenes are bridged as a list of strings
-            return [sta::scenes]
+            set result [list]
+            foreach scene [sta::scenes] {
+                lappend result [scene_name $scene]
+            }
+            return $result
         } else {
             # corners are not bridged as strings
             set result [list]
@@ -36,12 +48,14 @@ namespace eval lln {
     proc get_corner_dict {} {
         # returns: Tcl dictionary from corner names to whatever object is
         # interpreted as a corner for internal commands that expect corners:
-        # - in OpenSTA 3, that's the scene's name again
+        # - in OpenSTA 3, that's whatever sta::find_scene returns (a name in
+        #   OpenSTA 3.0, a Scene object since 3.1)
         # - in OpenSTA 2, that's an opaque Tcl pointer
         set result [dict create]
         if {[string length [namespace which sta::scenes]] != 0} {
             foreach scene [sta::scenes] {
-                dict set result $scene $scene
+                set name [scene_name $scene]
+                dict set result $name [sta::find_scene $name]
             }
         } else {
             foreach corner [sta::corners] {
@@ -52,7 +66,11 @@ namespace eval lln {
     }
 
     proc set_sta_cmd_corner {corner_name} {
-        if {[string length [namespace which sta::set_cmd_scene]] != 0} {
+        # sta::set_scene takes a name in every OpenSTA 3; sta::set_cmd_scene
+        # takes a name before 998806cb and a Scene object after.
+        if {[string length [namespace which sta::set_scene]] != 0} {
+            sta::set_scene $corner_name
+        } elseif {[string length [namespace which sta::set_cmd_scene]] != 0} {
             sta::set_cmd_scene $corner_name
         } else {
             set corner_object [sta::find_corner $corner_name]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.11"
+version = "3.0.12"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
Since OpenSTA 998806cb (2026-06-30), `sta::scenes` returns SWIG objects instead of names, and `set_cmd_scene` only accepts the object, whereas `worst_slack -corner` only accepts the name: `io.tcl` assumed strings everywhere, causing the pre-PnR STA step to fail with `_p_Scene is not the name of a scene`.

A `scene_name` helper (guarded by `is_object`, then `get_property name`) feeds `get_corner_names` and `get_corner_dict`, the latter mapping each name to whatever `sta::find_scene` returns; `set_sta_cmd_corner` now prefers `sta::set_scene`, which accepts a name across the entire OpenSTA 3 series.

Compatible with both the February 2026 OpenSTA pinned by librelane and the July one.