### PR TITLE
[low priority] repair_design: Add missing variable + argument update

### DIFF
--- a/librelane/scripts/openroad/repair_design.tcl
+++ b/librelane/scripts/openroad/repair_design.tcl
@@ -49,11 +49,11 @@ lappend arg_list -verbose
 lappend arg_list -max_wire_length $::env(DESIGN_REPAIR_MAX_WIRE_LENGTH)
 lappend arg_list -slew_margin $::env(DESIGN_REPAIR_MAX_SLEW_PCT)
 lappend arg_list -cap_margin $::env(DESIGN_REPAIR_MAX_CAP_PCT)
-if { [info exists ::env(DESIGN_REPAIR_MAX_UTILIZATION)] } {
+if { [info exists $::env(DESIGN_REPAIR_MAX_UTILIZATION)] } {
     lappend arg_list -max_utilization $::env(DESIGN_REPAIR_MAX_UTILIZATION)
 }
-if { [info exists ::env(DESIGN_REPAIR_BUFFER_GAIN)] } {
-    lappend arg_list -buffer_gain $::env(DESIGN_REPAIR_BUFFER_GAIN)
+if { $::env(DESIGN_REPAIR_PRE_PLACEMENT) } {
+    lappend arg_list -pre_placement
 }
 # Repair Design
 log_cmd repair_design {*}$arg_list

--- a/librelane/scripts/openroad/repair_design.tcl
+++ b/librelane/scripts/openroad/repair_design.tcl
@@ -49,7 +49,7 @@ lappend arg_list -verbose
 lappend arg_list -max_wire_length $::env(DESIGN_REPAIR_MAX_WIRE_LENGTH)
 lappend arg_list -slew_margin $::env(DESIGN_REPAIR_MAX_SLEW_PCT)
 lappend arg_list -cap_margin $::env(DESIGN_REPAIR_MAX_CAP_PCT)
-if { [info exists $::env(DESIGN_REPAIR_MAX_UTILIZATION)] } {
+if { $::env(DESIGN_REPAIR_MAX_UTILIZATION) > 0 } {
     lappend arg_list -max_utilization $::env(DESIGN_REPAIR_MAX_UTILIZATION)
 }
 if { $::env(DESIGN_REPAIR_PRE_PLACEMENT) } {

--- a/librelane/scripts/openroad/repair_design_postgrt.tcl
+++ b/librelane/scripts/openroad/repair_design_postgrt.tcl
@@ -40,9 +40,7 @@ if { [info exists $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)] } {
     lappend arg_list -max_utilization $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)
 }
 
-if { $::env(GRT_DESIGN_REPAIR_PRE_PLACEMENT) } {
-    lappend arg_list -pre_placement
-}
+
 log_cmd repair_design {*}$arg_list
 
 # Re-DPL and GRT

--- a/librelane/scripts/openroad/repair_design_postgrt.tcl
+++ b/librelane/scripts/openroad/repair_design_postgrt.tcl
@@ -36,12 +36,12 @@ lappend arg_list -verbose
 lappend arg_list -max_wire_length $::env(GRT_DESIGN_REPAIR_MAX_WIRE_LENGTH)
 lappend arg_list -slew_margin $::env(GRT_DESIGN_REPAIR_MAX_SLEW_PCT)
 lappend arg_list -cap_margin $::env(GRT_DESIGN_REPAIR_MAX_CAP_PCT)
-if { [info exists ::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)] } {
+if { [info exists $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)] } {
     lappend arg_list -max_utilization $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)
 }
 
-if { [info exists ::env(GRT_DESIGN_REPAIR_BUFFER_GAIN)] } {
-    lappend arg_list -buffer_gain $::env(GRT_DESIGN_REPAIR_BUFFER_GAIN)
+if { $::env(GRT_DESIGN_REPAIR_PRE_PLACEMENT) } {
+    lappend arg_list -pre_placement
 }
 log_cmd repair_design {*}$arg_list
 

--- a/librelane/scripts/openroad/repair_design_postgrt.tcl
+++ b/librelane/scripts/openroad/repair_design_postgrt.tcl
@@ -39,8 +39,6 @@ lappend arg_list -cap_margin $::env(GRT_DESIGN_REPAIR_MAX_CAP_PCT)
 if { $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION) > 0 } {
     lappend arg_list -max_utilization $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)
 }
-
-
 log_cmd repair_design {*}$arg_list
 
 # Re-DPL and GRT

--- a/librelane/scripts/openroad/repair_design_postgrt.tcl
+++ b/librelane/scripts/openroad/repair_design_postgrt.tcl
@@ -39,6 +39,7 @@ lappend arg_list -cap_margin $::env(GRT_DESIGN_REPAIR_MAX_CAP_PCT)
 if { [info exists ::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)] } {
     lappend arg_list -max_utilization $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)
 }
+
 if { [info exists ::env(GRT_DESIGN_REPAIR_BUFFER_GAIN)] } {
     lappend arg_list -buffer_gain $::env(GRT_DESIGN_REPAIR_BUFFER_GAIN)
 }

--- a/librelane/scripts/openroad/repair_design_postgrt.tcl
+++ b/librelane/scripts/openroad/repair_design_postgrt.tcl
@@ -36,7 +36,7 @@ lappend arg_list -verbose
 lappend arg_list -max_wire_length $::env(GRT_DESIGN_REPAIR_MAX_WIRE_LENGTH)
 lappend arg_list -slew_margin $::env(GRT_DESIGN_REPAIR_MAX_SLEW_PCT)
 lappend arg_list -cap_margin $::env(GRT_DESIGN_REPAIR_MAX_CAP_PCT)
-if { [info exists $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)] } {
+if { $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION) > 0 } {
     lappend arg_list -max_utilization $::env(GRT_DESIGN_REPAIR_MAX_UTILIZATION)
 }
 

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2636,6 +2636,18 @@ class RepairDesignPostGPL(ResizerStep):
             "Invokes OpenROAD's remove_buffers command to remove buffers from synthesis, which gives OpenROAD more flexibility when buffering nets.",
             default=False,
         ),
+        Variable(
+            "DESIGN_REPAIR_MAX_UTILIZATION",
+            Decimal,
+            "Defines the percentage of core area used.",
+            units="%",
+        ), 
+        Variable(
+            "DESIGN_REPAIR_PRE_PLACEMENT",
+            bool,
+            "Enables performing an initial pre-placement sizing and buffering round.",
+            default=False,
+        ),        
     ]
 
     def get_script_path(self):

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2692,6 +2692,18 @@ class RepairDesignPostGRT(ResizerStep):
             units="%",
             deprecated_names=["GLB_RESIZER_MAX_CAP_MARGIN"],
         ),
+        Variable(
+            "GRT_DESIGN_REPAIR_MAX_UTILIZATION",
+            Decimal,
+            "Defines the percentage of core area used during post-grt repair.",
+            units="%",
+        ),    
+        Variable(
+            "GRT_DESIGN_REPAIR_PRE_PLACEMENT",
+            bool,
+            "Enables performing an initial pre-placement sizing and buffering round.",
+            default=False,
+        ),       
     ]
 
     def get_script_path(self):

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2698,12 +2698,6 @@ class RepairDesignPostGRT(ResizerStep):
             "Defines the percentage of core area used during post-grt repair.",
             units="%",
         ),    
-        Variable(
-            "GRT_DESIGN_REPAIR_PRE_PLACEMENT",
-            bool,
-            "Enables performing an initial pre-placement sizing and buffering round.",
-            default=False,
-        ),       
     ]
 
     def get_script_path(self):

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2642,13 +2642,13 @@ class RepairDesignPostGPL(ResizerStep):
             "Defines the percentage of core area used.",
             units="%",
             default=0,
-        ), 
+        ),
         Variable(
             "DESIGN_REPAIR_PRE_PLACEMENT",
             bool,
             "Enables performing an initial pre-placement sizing and buffering round.",
             default=False,
-        ),        
+        ),
     ]
 
     def get_script_path(self):
@@ -2711,7 +2711,7 @@ class RepairDesignPostGRT(ResizerStep):
             "Defines the percentage of core area used during post-grt repair.",
             units="%",
             default=0,
-        ),    
+        ),
     ]
 
     def get_script_path(self):

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -2641,6 +2641,7 @@ class RepairDesignPostGPL(ResizerStep):
             Decimal,
             "Defines the percentage of core area used.",
             units="%",
+            default=0,
         ), 
         Variable(
             "DESIGN_REPAIR_PRE_PLACEMENT",
@@ -2709,6 +2710,7 @@ class RepairDesignPostGRT(ResizerStep):
             Decimal,
             "Defines the percentage of core area used during post-grt repair.",
             units="%",
+            default=0,
         ),    
     ]
 


### PR DESCRIPTION
While comparing against the openroad doc I noticed a few minor issues with the post gpl and grt scripts, this PR is my small fix. 

Changes: 
- Exposed the `*_MAX_UTILIZATION` variables, this variable was referenced in the tcl scripts but never set anywhere. 
- Removed the `-buffer_gain` argument from `repair_design` as it has been deprecated: https://openroad.readthedocs.io/en/latest/main/src/rsz/README.html#repair-design
- Replace use of `-buffer_gain` with `-pre_placement` from post gpl, similarly to what is already done on the openroad side: (https://github.com/The-OpenROAD-Project/OpenROAD/blob/2ac546acaf350111732655ae402ea952d06d362c/src/rsz/src/Resizer.tcl#L164-L167). 
- Remove `-buffer_gain` with no substitution for the post grl repair. Didn't think calling `-pre-placement` post routing sounded like a good idea. 


Notes: 
- Since `*_BUFFER_GAIN` was also never exposed to the config there is no risk of breaking anyone's configs. 

Things I am less certain of:
- Is there a need to invoke `-pre-placement` post grl ? 

