### PR TITLE
Odb.CheckMacroAntennaProperties: check every cell, not just the first

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,12 @@ Style Notes
   * Enabled maskhints so that DRC rules against generated layers are run
     against the closest possible version to what's actually in the GDS.
 
+* `Odb.CheckMacroAntennaProperties`
+
+  * Fixed `check_cells` returning inside its loop, which meant only the first
+    macro was ever checked: later macros produced no warnings and were absent
+    from the report. It also no longer returns `None` when given no cells.
+
 * `Odb.SetPowerConnections`
 
   * Consider busses in power/ground ports. Before, i.e., `VCCD_PAD[0]` and `VCCD_PAD[1]` would be shorted to `VCCD_PAD`.

--- a/librelane/scripts/odbpy/check_antenna_properties.py
+++ b/librelane/scripts/odbpy/check_antenna_properties.py
@@ -65,7 +65,7 @@ def check_cells(odb_cells):
         }
         report.append(entry)
 
-        return report
+    return report
 
 
 def get_top_level_cell(input_lefs, design_lef, cell_name):


### PR DESCRIPTION
Fixes #1022.

`check_cells` had `return report` inside its `for cell in odb_cells:` loop, so it returned after one iteration. Every later cell was skipped: no warnings printed, and no entry in the YAML report.

As @mole99 noted on the issue, `Odb.CheckDesignAntennaProperties` was never affected — it passes only the top-level cell, so one iteration was always enough. `Odb.CheckMacroAntennaProperties` passes every macro, so it reported one and silently ignored the rest.

## The change

One line, dedenting the return out of the loop:

```diff
         report.append(entry)
 
-        return report
+    return report
```

That also fixes `check_cells` returning `None` when given no cells — it now returns an empty list, as the annotation implies.

## Verification

Against the three cells from the issue report (`PADCELL_SIG_H`, `PADCELL_SIG_V`, `PADCELL_VDDIO_H`), all of which have pins meeting the warning conditions:

| | 3 cells in | no cells in |
| --- | --- | --- |
| before | 1 reported — `['PADCELL_SIG_H']` | `None` |
| after | 3 reported — all three, each warned | `[]` |

The observable end-to-end behaviour is in the issue: on `2.4.6` and `3.0.2`, three requested cells produced warnings and a report entry for exactly one.

## Notes

Targets `dev`, per the contributor notes. Changelog entry added under `3.1.0` → `Steps`, alphabetically before `Odb.SetPowerConnections`.

No test is added: there is no existing test around `odbpy/check_antenna_properties.py` to extend, and the script needs a live ODB plus the `reader` runtime, so a meaningful one would be a new fixture rather than a change here. Happy to add one if you'd like it in this PR.