### PR TITLE
fix: `Odb.CheckMacroAntennaProperties` only checks first macro

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,14 @@ Style Notes
 
 -->
 
+# 3.0.12
+
+## Steps
+
+* `Odb.CheckMacroAntennaProperties`
+
+  * Fixed an issue where the report would always return once the first macro had been checked.
+
 # 3.0.11
 
 ## Tool Updates

--- a/librelane/scripts/odbpy/check_antenna_properties.py
+++ b/librelane/scripts/odbpy/check_antenna_properties.py
@@ -65,7 +65,7 @@ def check_cells(odb_cells):
         }
         report.append(entry)
 
-        return report
+    return report
 
 
 def get_top_level_cell(input_lefs, design_lef, cell_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.11"
+version = "3.0.12"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
The loop would always return after checking the first macro.

* `Odb.CheckMacroAntennaProperties`

  * Fixed an issue where the report would always return once the first macro had been checked.

Fixes #1022