### PR TITLE
docs: correct hold arrival time formula in timing closure doc

### DIFF
--- a/docs/source/usage/timing_closure/index.md
+++ b/docs/source/usage/timing_closure/index.md
@@ -274,11 +274,11 @@ The RAT (Required Arrival Time) is calculated using the following:
 To satisfy the setup constraint, the latest AAT should be less than $ RAT_{setup} $. In
 another words:
 
-(3) $ SLACK_{setup} = RAT_{setup} - ATT_{latest} > 0 $
+(3) $ SLACK_{setup} = RAT_{setup} - AAT_{latest} > 0 $
 
 For hold constraint check, we use the earliest arrival time
 
-(4) $ AAT_{earliest} = t_{ck} + t_{CQ} + t_{xor} $
+(4) $ AAT_{earliest} = t_{CQ} + t_{xor} $
 
 and the required time can be calculated
 
@@ -287,7 +287,7 @@ and the required time can be calculated
 To satisfy the hold constraint, the earliest AAT should be larger than the $
 RAT_{hold} $, which means:
 
-(6) $ SLACK_{hold} = ATT_{earliest} - RAT_{hold} > 0 $
+(6) $ SLACK_{hold} = AAT_{earliest} - RAT_{hold} > 0 $
 
 ### Timing Optimizations
 


### PR DESCRIPTION
Removes \	_{ck}\ from the hold constraint arrival time formula (4) as hold slack is clock frequency independent. Also fixes \ATT\ -> \AAT\ typos in formulas (3) and (6).

Closes #974