### PR TITLE
fix: resolve PAD_LIBS per corner instead of iterating the dict flat

### DIFF
--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -236,8 +236,8 @@ proc read_timing_info {args} {
         }
     }
     
-    if { [info exists ::env(PAD_LIBS) ] } {
-        foreach lib $::env(PAD_LIBS) {
+    if { [info exists ::env(_CURRENT_CORNER_PAD_LIBS) ] } {
+        foreach lib $::env(_CURRENT_CORNER_PAD_LIBS) {
             puts "Reading gpio pad timing for the '$corner_name' corner at '$lib'…"
             read_liberty -corner $corner_name $lib
         }
@@ -344,8 +344,8 @@ proc read_pnr_libs {args} {
             }
         }
         
-        if { [info exists ::env(PAD_LIBS) ] } {
-            foreach pad_lib $::env(PAD_LIBS) {
+        if { [info exists ::env(_CURRENT_CORNER_PAD_LIBS) ] } {
+            foreach pad_lib $::env(_CURRENT_CORNER_PAD_LIBS) {
                 puts "Reading gpio pad timing library for the '$corner_name' corner at '$pad_lib'…"
                 read_liberty -corner $corner_name $pad_lib
             }

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -557,11 +557,13 @@ class OpenSTAStep(OpenROADStep):
         libs: Tuple[str, ...]
         netlists: Tuple[str, ...]
         spefs: Tuple[Tuple[str, str], ...]
+        pad_libs: Tuple[str, ...] = ()
         extra_spefs_backcompat: Optional[Tuple[Tuple[str, str], ...]] = None
         current_corner_spef: Optional[str] = None
 
         def set_env(self, env: Dict[str, Any]):
             env["_CURRENT_CORNER_LIBS"] = TclStep.value_to_tcl(self.libs)
+            env["_CURRENT_CORNER_PAD_LIBS"] = TclStep.value_to_tcl(self.pad_libs)
             env["_CURRENT_CORNER_NETLISTS"] = TclStep.value_to_tcl(self.netlists)
             env["_CURRENT_CORNER_SPEFS"] = TclStep.value_to_tcl(self.spefs)
             if self.extra_spefs_backcompat is not None:
@@ -594,6 +596,12 @@ class OpenSTAStep(OpenROADStep):
             prioritize_nl=prioritize_nl,
             timing_corner=timing_corner,
         )
+
+        pad_libs: List[Path] = []
+        if pad_libs_by_corner := self.config.get("PAD_LIBS"):
+            pad_libs = self.toolbox.filter_views(
+                self.config, pad_libs_by_corner, timing_corner
+            )
         state_in = self.state_in.result()
 
         name = timing_corner
@@ -656,6 +664,7 @@ class OpenSTAStep(OpenROADStep):
             name,
             OpenSTAStep.CornerFileList(
                 libs=tuple([str(lib) for lib in libs]),
+                pad_libs=tuple([str(lib) for lib in pad_libs]),
                 netlists=tuple([str(netlist) for netlist in netlists]),
                 spefs=tuple([(pair[0], str(pair[1])) for pair in spefs]),
                 extra_spefs_backcompat=extra_spefs_backcompat,


### PR DESCRIPTION
Fixes the `PAD_LIBS` handling described in #1028.

## Problem

`PAD_LIBS` is declared `Optional[Dict[str, List[Path]]]` (corner pattern → libs) in `config/flow.py`, but `scripts/openroad/common/io.tcl` iterates it with a flat `foreach`. A Tcl dict serialises as an interleaved key/value list, so the corner globs themselves get passed to `read_liberty`:

```
Error: cannot read file *_tt_025C_5v00.
```

The neighbouring variables in the same proc show the asymmetry:

| Variable | Declared type | Tcl consumption |
|---|---|---|
| `LIB` | `Dict[str, List[Path]]` | resolved to `_CURRENT_CORNER_LIBS` via `filter_views` first ✅ |
| `EXTRA_LIBS` | `List[Path]` | flat `foreach` — type matches ✅ |
| `PAD_LIBS` | `Dict[str, List[Path]]` | flat `foreach` — type does not match ❌ |

## Why it's worth fixing rather than documenting

The natural workaround is `PAD_LIBS: null`, and it fails silently in the dangerous direction. With no liberty for the clock pad cell, `create_clock` on the pad port has nothing to propagate through, so STA analyses **zero paths** and then reports **zero setup/hold violations in every corner** — a summary indistinguishable at a glance from a design that genuinely closes timing.

## Change

Resolve `PAD_LIBS` per corner the same way `LIB` already is, using the existing `Toolbox.filter_views`, and expose it to Tcl pre-filtered as `_CURRENT_CORNER_PAD_LIBS`. Both `io.tcl` call sites updated. 13 lines.

## Verification

Tested on a gf180mcu chip-with-padring design (46 bidir + 4 input pads, ~12k registers), running the full flow:

| Configuration | Result |
|---|---|
| before, `PAD_LIBS` dict | `Error: cannot read file *_tt_025C_5v00.` |
| before, `PAD_LIBS: null` | `11987 unclocked register/latch pins`, `No paths found` |
| **after, `PAD_LIBS` dict** | `Reading gpio pad timing for the 'nom_tt_025C_3v30' corner at '…gf180mcu_fd_io__tt_025C_3v30.lib'`, **4004 paths clocked by `clk_PAD`, 0 unclocked warnings** |

The corner filtering is exercised, not bypassed: a three-entry `PAD_LIBS` dict correctly selects the `tt_025C_3v30` pad liberty for the `nom_tt_025C_3v30` corner.

Note the patch was developed against `main` and validated by running the same change against the installed 3.0.8 (identical code in both), since that matched the dependency set available locally.