### PR TITLE
fix: improper processing of PAD_LIBS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,25 @@ Style Notes
 
 -->
 
+# 3.0.14
+
+## Steps
+
+* `Odb.*`
+  * Fixed steps not loading `PAD_LIBS`.
+
+* `OpenROAD.*`
+  * Fixed a crash when `PAD_LIBS` is set to a non-None value.
+
+* `Yosys.*`
+  * Fixed steps not loading `PAD_LIBS`.
+  
+## Misc. Enhancements/Bugfixes
+
+* `openlane.common`
+  * `Toolbox.get_timing_files_categorized` now includes any corner-appropriate
+    `PAD_LIBS`.
+
 # 3.0.13
 
 ## Steps

--- a/librelane/common/toolbox.py
+++ b/librelane/common/toolbox.py
@@ -232,9 +232,14 @@ class Toolbox(object):
 
         timing_corner = timing_corner or config["DEFAULT_CORNER"]
 
+        # Filter the cell libs
         all_libs: List[Path] = self.filter_views(config, config["LIB"], timing_corner)
         if len(all_libs) == 0:
             warn(f"No SCL lib files found for {timing_corner}.")
+
+        # Add optional I/O pad libs
+        if pad_libs := config.get("PAD_LIBS"):
+            all_libs += self.filter_views(config, pad_libs, timing_corner)
 
         all_netlists: List[Path] = []
         all_spefs: List[Tuple[str, Path]] = []

--- a/librelane/config/flow.py
+++ b/librelane/config/flow.py
@@ -427,15 +427,21 @@ option_variables = [
 
 pad_variables = [
     Variable(
-        "PAD_GDS",
-        Optional[List[Path]],
-        "Path(s) to IO pad GDS file(s).",
+        "PAD_LIBS",
+        Optional[Dict[str, List[Path]]],
+        "A map from corner patterns to a list of associated liberty files. Exactly one entry must match the `DEFAULT_CORNER`.",
         pdk=True,
     ),
     Variable(
         "PAD_LEFS",
         Optional[List[Path]],
         "Path(s) to IO pad LEF file(s).",
+        pdk=True,
+    ),
+    Variable(
+        "PAD_GDS",
+        Optional[List[Path]],
+        "Path(s) to IO pad GDS file(s).",
         pdk=True,
     ),
     Variable(
@@ -454,12 +460,6 @@ pad_variables = [
         "PAD_CDLS",
         Optional[List[Path]],
         description="A circuit-design language view of the io pad library.",
-        pdk=True,
-    ),
-    Variable(
-        "PAD_LIBS",
-        Optional[Dict[str, List[Path]]],
-        "A map from corner patterns to a list of associated liberty files. Exactly one entry must match the `DEFAULT_CORNER`.",
         pdk=True,
     ),
     Variable(

--- a/librelane/scripts/openroad/common/io.tcl
+++ b/librelane/scripts/openroad/common/io.tcl
@@ -253,13 +253,6 @@ proc read_timing_info {args} {
             read_liberty -corner $corner_name $extra_lib
         }
     }
-    
-    if { [info exists ::env(PAD_LIBS) ] } {
-        foreach lib $::env(PAD_LIBS) {
-            puts "Reading gpio pad timing for the '$corner_name' corner at '$lib'…"
-            read_liberty -corner $corner_name $lib
-        }
-    }
 
     set blackbox_wildcard {/// sta-blackbox}
     foreach nl $::env(_CURRENT_CORNER_NETLISTS) {
@@ -359,13 +352,6 @@ proc read_pnr_libs {args} {
             foreach extra_lib $::env(EXTRA_LIBS) {
                 puts "Reading extra timing library for the '$corner_name' corner at '$extra_lib'…"
                 read_liberty -corner $corner_name $extra_lib
-            }
-        }
-        
-        if { [info exists ::env(PAD_LIBS) ] } {
-            foreach pad_lib $::env(PAD_LIBS) {
-                puts "Reading gpio pad timing library for the '$corner_name' corner at '$pad_lib'…"
-                read_liberty -corner $corner_name $pad_lib
             }
         }
     }

--- a/librelane/steps/odb.py
+++ b/librelane/steps/odb.py
@@ -973,6 +973,8 @@ class CellFrequencyTables(OdbpyStep):
 
         env_copy = env.copy()
         lib_list = self.toolbox.filter_views(self.config, self.config["LIB"])
+        if pad_libs := self.config.get("PAD_LIBS"):
+            lib_list += self.toolbox.filter_views(self.config, pad_libs)
         env_copy["_PNR_LIBS"] = TclStep.value_to_tcl(lib_list)
         super().run_subprocess(
             [

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -318,6 +318,8 @@ class OpenROADStep(TclStep):
         env = super().prepare_env(env, state)
 
         lib_list = self.toolbox.filter_views(self.config, self.config["LIB"])
+        if pad_libs := self.config.get("PAD_LIBS"):
+            lib_list += self.toolbox.filter_views(self.config, pad_libs)
         lib_list += self.toolbox.get_macro_views(self.config, DesignFormat.LIB)
 
         env["_SDC_IN"] = self.config["PNR_SDC_FILE"] or self.config["FALLBACK_SDC"]
@@ -2240,6 +2242,8 @@ class IRDropReport(OpenROADStep):
             raise StepException("No SPEF file found for the default corner.")
 
         libs_in = self.toolbox.filter_views(self.config, self.config["LIB"])
+        if pad_libs := self.config.get("PAD_LIBS"):
+            libs_in += self.toolbox.filter_views(self.config, pad_libs)
 
         if self.config["VSRC_LOC_FILES"] is None:
             self.warn(

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -284,7 +284,13 @@ class VerilogStep(PyosysStep):
         scl_lib_list = self.toolbox.filter_views(
             self.config, self.config["LIB"], self.config.get("SYNTH_CORNER")
         )
+        pad_lib_list = []
+        if pad_libs := self.config.get("PAD_LIBS"):
+            pad_lib_list = self.toolbox.filter_views(
+                self.config, pad_libs, self.config.get("SYNTH_CORNER")
+            )
 
+        # Try your best to use powered blackbox models if power_defines is true
         if self.power_defines:
             if self.config["CELL_VERILOG_MODELS"] is not None:
                 blackbox_models.extend(
@@ -305,7 +311,8 @@ class VerilogStep(PyosysStep):
                     ]
                 )
         else:
-            blackbox_models.extend(str(f) for f in scl_lib_list)
+            # Fall back to scl_lib_list and pad_lib_list if you cant
+            blackbox_models.extend(str(f) for f in scl_lib_list + pad_lib_list)
 
         # Priorities from higher to lower
         format_list = (
@@ -340,7 +347,7 @@ class VerilogStep(PyosysStep):
         excluded_cells.update(process_list_file(self.config["PNR_EXCLUDED_CELL_FILE"]))
 
         libs_synth = self.toolbox.remove_cells_from_lib(
-            frozenset([str(lib) for lib in scl_lib_list]),
+            frozenset([str(lib) for lib in scl_lib_list + pad_lib_list]),
             excluded_cells=frozenset(excluded_cells),
         )
         extra_path = os.path.join(self.step_dir, "extra.json")

--- a/librelane/steps/yosys.py
+++ b/librelane/steps/yosys.py
@@ -70,6 +70,9 @@ def _generate_read_deps(
             )
 
     scl_lib_list = toolbox.filter_views(config, config["LIB"])
+    pad_lib_list = []
+    if pad_libs := config.get("PAD_LIBS"):
+        pad_lib_list = toolbox.filter_views(config, pad_libs)
 
     if power_defines:
         if power_define := config.get(
@@ -94,8 +97,8 @@ def _generate_read_deps(
             )
             commands += f"read_verilog -sv -lib {pad_blackbox_models}\n"
     else:
-        # Fall back to scl_lib_list if you cant
-        for lib in scl_lib_list:
+        # Fall back to scl_lib_list and pad_lib_list if you cant
+        for lib in scl_lib_list + pad_lib_list:
             lib_str = TclUtils.escape(str(lib))
             commands += (
                 f"read_liberty -lib -ignore_miss_dir -setattr blackbox {lib_str}\n"
@@ -106,7 +109,7 @@ def _generate_read_deps(
     excluded_cells.update(process_list_file(config["PNR_EXCLUDED_CELL_FILE"]))
 
     lib_synth = toolbox.remove_cells_from_lib(
-        frozenset([str(lib) for lib in scl_lib_list]),
+        frozenset([str(lib) for lib in scl_lib_list + pad_lib_list]),
         excluded_cells=frozenset(excluded_cells),
     )
     if tcl:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librelane"
-version = "3.0.13"
+version = "3.0.14"
 description = "An infrastructure for implementing chip design flows"
 maintainers = [
     {name = "Mohamed Gaber", email = "donn@fossi-foundation.org"},


### PR DESCRIPTION
(partial backport of #925 from dev)

I did actively choose one deviation from #925 here, which is that I did not retroactively set a default for PAD_LIBS. The reason is existing configurations with PAD_LIBS explicitly set to None, such as for reproducible steps and indeed test_toolbox.py, would all fail.

---

Resolves #1030
Supersedes #1029 