### PR TITLE
Yosys.*Synthesis: support abc_new

### DIFF
--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -288,7 +288,7 @@ def synthesize(
     # https://github.com/YosysHQ/abc/blob/28d955ca97a1c4be3aed4062aec0241a734fac5d/src/map/scl/sclUtil.c#L257
     sdc_path = os.path.join(step_dir, "synthesis.abc.sdc")
     with open(sdc_path, "w") as f:
-        print(f"set_driving_cell {config['SYNTH_DRIVING_CELL'].split("/")[0]}", file=f)
+        print(f"set_driving_cell {config['SYNTH_DRIVING_CELL'].split('/')[0]}", file=f)
         print(f"set_load {config['OUTPUT_CAP_LOAD']}", file=f)
 
     ys.log(f"[INFO] Using SDC file '{sdc_path}' for ABC…")

--- a/librelane/scripts/pyosys/synthesize.py
+++ b/librelane/scripts/pyosys/synthesize.py
@@ -288,7 +288,7 @@ def synthesize(
     # https://github.com/YosysHQ/abc/blob/28d955ca97a1c4be3aed4062aec0241a734fac5d/src/map/scl/sclUtil.c#L257
     sdc_path = os.path.join(step_dir, "synthesis.abc.sdc")
     with open(sdc_path, "w") as f:
-        print(f"set_driving_cell {config['SYNTH_DRIVING_CELL']}", file=f)
+        print(f"set_driving_cell {config['SYNTH_DRIVING_CELL'].split("/")[0]}", file=f)
         print(f"set_load {config['OUTPUT_CAP_LOAD']}", file=f)
 
     ys.log(f"[INFO] Using SDC file '{sdc_path}' for ABC…")
@@ -465,24 +465,36 @@ def synthesize(
     def run_strategy(d):
         abc_script = config["SYNTH_ABC_STRATEGY_SCRIPT"]
         if abc_script:
-            ys.log(f"[INFO] Using custom ABC strategy script '{abc_script}'…")
-        else:
+            ys.log(f"[INFO] Using custom ABC strategy script '{abc_script}'…\n")
+        elif not config["SYNTH_ABC_NEW"]:
             abc_script = script_creator.generate_abc_script(
                 step_dir,
                 config["SYNTH_STRATEGY"],
             )
-            ys.log(f"[INFO] Using generated ABC strategy script '{abc_script}'…")
+            ys.log(f"[INFO] Using generated ABC strategy script '{abc_script}'…\n")
+        ys.log_flush()
 
-        d.run_pass(
-            "abc",
-            "-script",
-            abc_script,
+        old_abc_args = []
+        if not config["SYNTH_ABC_NEW"]:
+            old_abc_args = ["-showtmp"]
+            if abc_script is not None:
+                old_abc_args.extend(("-script", abc_script))
+            if config["SYNTH_ABC_DFF"]:
+                old_abc_args.append("-dff")
+
+        dont_use_args = []
+        for excluded_cell in extra["excluded_cell_patterns"]:
+            dont_use_args.extend(("-dont_use", excluded_cell))
+
+        abc_pass = [
+            "abc_new" if config["SYNTH_ABC_NEW"] else "abc",
             "-constr",
             sdc_path,
-            "-showtmp",
             *lib_arguments,
-            *(["-dff"] if config["SYNTH_ABC_DFF"] else []),
-        )
+            *old_abc_args,
+            *dont_use_args,
+        ]
+        d.run_pass(*abc_pass)
 
         if value := config.get("SYNTH_TIE_UNDEFINED"):
             flag = "-zero" if value == "low" else "-one"

--- a/librelane/scripts/pyosys/ys_common.py
+++ b/librelane/scripts/pyosys/ys_common.py
@@ -151,6 +151,8 @@ def _Design_add_blackbox_models(
                 "-sv",
                 "-setattr",
                 "keep_hierarchy",
+                "-setattr",
+                "blackbox",
                 "-lib",
                 *include_args,
                 *define_args,
@@ -165,6 +167,7 @@ def _Design_add_blackbox_models(
                 "blackbox",
                 "-setattr",
                 "keep_hierarchy",
+                "-unit_delay",
                 model,
             )
         else:

--- a/librelane/steps/openroad.py
+++ b/librelane/steps/openroad.py
@@ -516,7 +516,7 @@ class OpenROADStep(TclStep):
 
     def get_command(self) -> List[str]:
         metrics_path = os.path.join(self.step_dir, "or_metrics_out.json")
-        threads = str(self.config["OPENROAD_THREADS"]) or str(_get_process_limit())
+        threads = str(self.config["OPENROAD_THREADS"] or _get_process_limit())
         verbose(f"OpenROAD will use {threads} threads")
         return [
             self.get_openroad_path(),

--- a/librelane/steps/pyosys.py
+++ b/librelane/steps/pyosys.py
@@ -268,7 +268,7 @@ class PyosysStep(Step):
         env["PYTHONPATH"] = ":".join(
             (env.get("PYTHONPATH", ""), os.path.join(get_script_dir(), "pyosys"))
         )
-        subprocess_result = super().run_subprocess(cmd, env=env, **kwargs)
+        subprocess_result = self.run_subprocess(cmd, env=env, **kwargs)
         return {}, subprocess_result["generated_metrics"]
 
 
@@ -338,19 +338,27 @@ class VerilogStep(PyosysStep):
         if models := self.config.get("EXTRA_VERILOG_MODELS"):
             blackbox_models.extend(str(f) for f in models)
 
-        excluded_cells: Set[str] = set(self.config["EXTRA_EXCLUDED_CELLS"] or [])
-        excluded_cells.update(
+        excluded_cell_patterns: Set[str] = set(
+            self.config["EXTRA_EXCLUDED_CELLS"] or []
+        )
+        excluded_cell_patterns.update(
             process_list_file(self.config["SYNTH_EXCLUDED_CELL_FILE"])
         )
-        excluded_cells.update(process_list_file(self.config["PNR_EXCLUDED_CELL_FILE"]))
-
-        libs_synth = self.toolbox.remove_cells_from_lib(
-            frozenset([str(lib) for lib in scl_lib_list + pad_lib_list]),
-            excluded_cells=frozenset(excluded_cells),
+        excluded_cell_patterns.update(
+            process_list_file(self.config["PNR_EXCLUDED_CELL_FILE"])
         )
+
+        libs_synth = [str(p) for p in scl_lib_list + pad_lib_list]
         extra_path = os.path.join(self.step_dir, "extra.json")
         with open(extra_path, "w") as f:
-            json.dump({"blackbox_models": blackbox_models, "libs_synth": libs_synth}, f)
+            json.dump(
+                {
+                    "blackbox_models": blackbox_models,
+                    "libs_synth": libs_synth,
+                    "excluded_cell_patterns": list(excluded_cell_patterns),
+                },
+                f,
+            )
         cmd.extend(["--extra-in", extra_path])
         return cmd
 
@@ -412,6 +420,23 @@ class SynthesisCommon(VerilogStep):
             default=False,
         ),
         Variable(
+            "SYNTH_ABC_NEW",
+            bool,
+            "Experimental: Use the abc_new pass instead of abc, with the default synthesis strategy from Yosys.",
+            default=False,
+        ),
+        Variable(
+            "SYNTH_ABC_DFF",
+            bool,
+            "Passes D-flipflop cells through ABC for optimization (which can for example, eliminate identical flip-flops). Has no effect if SYNTH_ABC_NEW is true.",
+            default=False,
+        ),
+        Variable(
+            "SYNTH_ABC_STRATEGY_SCRIPT",
+            Optional[Path],
+            "Custom ABC strategy script, overriding either the default (if SYNTH_ABC_NEW is true) or the SYNTH_STRATEGY (if SYNTH_ABC_NEW is false). Has no effect if SYNTH_ABC_NEW is true.",
+        ),
+        Variable(
             "SYNTH_STRATEGY",
             Literal[
                 "AREA 0",
@@ -424,50 +449,39 @@ class SynthesisCommon(VerilogStep):
                 "DELAY 3",
                 "DELAY 4",
             ],
-            "Strategies for abc logic synthesis and technology mapping. AREA strategies usually result in a more compact design, while DELAY strategies usually result in a design that runs at a higher frequency. Please note that there is no way to know which strategy is the best before trying them.",
+            "Strategies for abc logic synthesis and technology mapping. AREA strategies usually result in a more compact design, while DELAY strategies usually result in a design that runs at a higher frequency. Please note that there is no way to know which strategy is the best before trying them. Has no effect if SYNTH_ABC_NEW is true or SYNTH_ABC_STRATEGY_SCRIPT is set.",
             default="DELAY 4",
         ),
         Variable(
             "SYNTH_ABC_BUFFERING",
             bool,
-            "Enables `abc` cell buffering.",
+            "Enables `abc` cell buffering. Has no effect if either SYNTH_ABC_NEW is true or SYNTH_ABC_STRATEGY_SCRIPT is set.",
             default=False,
             deprecated_names=["SYNTH_BUFFERING"],
         ),
         Variable(
             "SYNTH_ABC_LEGACY_REFACTOR",
             bool,
-            "Replaces the ABC command `drf -l` with `refactor` which matches older versions of LibreLane but is more unstable.",
+            "Replaces the ABC command `drf -l` with `refactor` which matches older versions of LibreLane but is more unstable. Has no effect if either SYNTH_ABC_NEW is true or SYNTH_ABC_STRATEGY_SCRIPT is set.",
             default=False,
         ),
         Variable(
             "SYNTH_ABC_LEGACY_REWRITE",
             bool,
-            "Replaces the ABC command `drw -l` with `rewrite` which matches older versions of LibreLane but is more unstable.",
-            default=False,
-        ),
-        Variable(
-            "SYNTH_ABC_DFF",
-            bool,
-            "Passes D-flipflop cells through ABC for optimization (which can for example, eliminate identical flip-flops).",
+            "Replaces the ABC command `drw -l` with `rewrite` which matches older versions of LibreLane but is more unstable. Has no effect if either SYNTH_ABC_NEW is true or SYNTH_ABC_STRATEGY_SCRIPT is set.",
             default=False,
         ),
         Variable(
             "SYNTH_ABC_USE_MFS3",
             bool,
-            "Experimental: attempts a SAT-based remapping in all area and delay strategies before 'retime', which may improve PPA results.",
+            "Experimental: attempts a SAT-based remapping in all area and delay strategies before 'retime', which may improve PPA results. Has no effect if either SYNTH_ABC_NEW is true or SYNTH_ABC_STRATEGY_SCRIPT is set.",
             default=False,
         ),
         Variable(
             "SYNTH_ABC_AREA_USE_NF",
             bool,
-            "Experimental: uses the &nf delay-based mapper with a very high value instead of the amap area mapper, which may be better in some scenarios at recovering area.",
+            "Experimental: uses the &nf delay-based mapper with a very high value instead of the amap area mapper, which may be better in some scenarios at recovering area. Has no effect if  either SYNTH_ABC_NEW is true or SYNTH_ABC_STRATEGY_SCRIPT is set.",
             default=False,
-        ),
-        Variable(
-            "SYNTH_ABC_STRATEGY_SCRIPT",
-            Optional[Path],
-            "Custom ABC strategy script. Runs instead of the default script for the selected 'SYNTH_STRATEGY'. All other 'SYNTH_ABC_*' variables except 'SYNTH_ABC_DFF' will have no effect.",
         ),
         Variable(
             "SYNTH_DIRECT_WIRE_BUFFERING",


### PR DESCRIPTION
- add experimental support for abc_new using `SYNTH_ABC_NEW` variable (default: false)
  - disables all abc strategy options other than `SYNTH_ABC_STRATEGY_SCRIPT` if set
- lib files are no longer trimmed for Yosys, -dont_use is passed to both abc and abc_new
- fix small issue in #937 where OpenROAD threads would be set to "None"
- fix abc sdc file setting driving cell incorrectly
- redocument every SYNTH_ABC variable to include their interactions